### PR TITLE
Uniffi compatible #1

### DIFF
--- a/src/analysis/ast_walker.rs
+++ b/src/analysis/ast_walker.rs
@@ -242,15 +242,15 @@ impl<'a, 'r> Walker<'a, 'r> {
 
         match inner {
             ast::Component::Ingredient(i) => Component {
-                kind: ComponentKind::Ingredient,
+                kind: ComponentKind::IngredientKind,
                 index: self.ingredient(Located::new(i, span)),
             },
             ast::Component::Cookware(c) => Component {
-                kind: ComponentKind::Cookware,
+                kind: ComponentKind::CookwareKind,
                 index: self.cookware(Located::new(c, span)),
             },
             ast::Component::Timer(t) => Component {
-                kind: ComponentKind::Timer,
+                kind: ComponentKind::TimerKind,
                 index: self.timer(Located::new(t, span)),
             },
         }

--- a/src/analysis/ast_walker.rs
+++ b/src/analysis/ast_walker.rs
@@ -683,7 +683,7 @@ fn find_temperature<'a>(text: &'a str, re: &Regex) -> Option<(&'a str, Quantity,
     let value = caps[1].replace(',', ".").parse::<f64>().ok()?;
     let unit = caps.get(3).unwrap().range();
     let unit_text = text[unit].to_string();
-    let temperature = Quantity::new(QuantityValue::Fixed { value: Value::Number(value) }, Some(unit_text));
+    let temperature = Quantity::new(QuantityValue::Fixed { value: Value::Number { value: value } }, Some(unit_text));
 
     let range = caps.get(0).unwrap().range();
     let (before, after) = (&text[..range.start], &text[range.end..]);

--- a/src/analysis/ast_walker.rs
+++ b/src/analysis/ast_walker.rs
@@ -204,19 +204,19 @@ impl<'a, 'r> Walker<'a, 'r> {
                     if let Some(re) = &self.temperature_regex {
                         if let Some((before, temperature, after)) = find_temperature(&t, re) {
                             if !before.is_empty() {
-                                new_items.push(Item::Text(before.to_string()));
+                                new_items.push(Item::Text { value: before.to_string() });
                             }
                             new_items
-                                .push(Item::InlineQuantity(self.content.inline_quantities.len()));
+                                .push(Item::InlineQuantity { value: self.content.inline_quantities.len() });
                             self.content.inline_quantities.push(temperature);
                             if !after.is_empty() {
-                                new_items.push(Item::Text(after.to_string()));
+                                new_items.push(Item::Text { value: after.to_string() });
                             }
                             continue;
                         }
                     }
 
-                    new_items.push(Item::Text(t.into_owned()));
+                    new_items.push(Item::Text { value: t.into_owned() });
                 }
                 ast::Item::Component(c) => {
                     if is_text {
@@ -226,7 +226,7 @@ impl<'a, 'r> Walker<'a, 'r> {
                         continue; // ignore component
                     }
                     let new_component = self.component(c);
-                    new_items.push(Item::Component(new_component))
+                    new_items.push(Item::ItemComponent { value: new_component })
                 }
             };
         }

--- a/src/analysis/ast_walker.rs
+++ b/src/analysis/ast_walker.rs
@@ -512,12 +512,12 @@ impl<'a, 'r> Walker<'a, 'r> {
             }
         }
         let value_span = value.span();
-        let mut value = QuantityValue::from_ast(value);
+        let mut v = QuantityValue::from_ast(value);
 
         if is_ingredient && self.auto_scale_ingredients {
-            match value {
-                QuantityValue::Fixed(v) => value = QuantityValue::Linear(v),
-                QuantityValue::Linear(_) => {
+            match v {
+                QuantityValue::Fixed { value } => v =  QuantityValue::Linear{ value },
+                QuantityValue::Linear { .. } => {
                     self.warn(AnalysisWarning::RedundantAutoScaleMarker {
                         quantity_span: Span::new(value_span.end(), value_span.end() + 1),
                     });
@@ -526,7 +526,7 @@ impl<'a, 'r> Walker<'a, 'r> {
             };
         }
 
-        value
+        v
     }
 
     fn resolve_reference<C: RefComponent>(
@@ -683,7 +683,7 @@ fn find_temperature<'a>(text: &'a str, re: &Regex) -> Option<(&'a str, Quantity,
     let value = caps[1].replace(',', ".").parse::<f64>().ok()?;
     let unit = caps.get(3).unwrap().range();
     let unit_text = text[unit].to_string();
-    let temperature = Quantity::new(QuantityValue::Fixed(Value::Number(value)), Some(unit_text));
+    let temperature = Quantity::new(QuantityValue::Fixed { value: Value::Number(value) }, Some(unit_text));
 
     let range = caps.get(0).unwrap().range();
     let (before, after) = (&text[..range.start], &text[range.end..]);

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -266,7 +266,7 @@ impl Recover for QuantityValue {
 
 impl Recover for Value {
     fn recover() -> Self {
-        Self::Number(1.0)
+        Self::Number { value: 1.0 }
     }
 }
 

--- a/src/convert/mod.rs
+++ b/src/convert/mod.rs
@@ -471,8 +471,8 @@ impl<'a> From<&'a Arc<Unit>> for ConvertTo<'a> {
 impl From<ConvertValue> for Value {
     fn from(value: ConvertValue) -> Self {
         match value {
-            ConvertValue::Number(n) => Self::Number(n),
-            ConvertValue::Range(r) => Self::Range(r),
+            ConvertValue::Number(n) => Self::Number { value: n },
+            ConvertValue::Range(r) => Self::Range { value: r },
         }
     }
 }
@@ -481,9 +481,9 @@ impl TryFrom<&Value> for ConvertValue {
     type Error = ConvertError;
     fn try_from(value: &Value) -> Result<Self, Self::Error> {
         let value = match value {
-            Value::Number(n) => ConvertValue::Number(*n),
-            Value::Range(r) => ConvertValue::Range(r.clone()),
-            Value::Text(t) => return Err(ConvertError::TextValue(t.to_string())),
+            Value::Number { value: n } => ConvertValue::Number(*n),
+            Value::Range { value: r } => ConvertValue::Range(r.clone()),
+            Value::Text { value: t } => return Err(ConvertError::TextValue(t.to_string())),
         };
         Ok(value)
     }

--- a/src/convert/mod.rs
+++ b/src/convert/mod.rs
@@ -231,17 +231,17 @@ impl Converter {
         };
 
         let (value, unit) = match &from.value {
-            QuantityValue::Fixed(v) => {
-                let (value, unit) = self.convert2(v.try_into()?, unit, to)?;
-                let q_value = QuantityValue::Fixed(value.into());
+            QuantityValue::Fixed{ value } => {
+                let (value, unit) = self.convert2(value.try_into()?, unit, to)?;
+                let q_value = QuantityValue::Fixed{ value: value.into()};
                 (q_value, unit)
             }
-            QuantityValue::Linear(v) => {
-                let (value, unit) = self.convert2(v.try_into()?, unit, to)?;
-                let q_value = QuantityValue::Linear(value.into());
+            QuantityValue::Linear{ value } => {
+                let (value, unit) = self.convert2(value.try_into()?, unit, to)?;
+                let q_value = QuantityValue::Linear{value: value.into()};
                 (q_value, unit)
             }
-            QuantityValue::ByServings(values) => {
+            QuantityValue::ByServings{values} => {
                 let mut new_values = Vec::with_capacity(values.len());
                 let mut new_unit = None;
                 for v in values {
@@ -249,7 +249,7 @@ impl Converter {
                     new_values.push(value.into());
                     new_unit = Some(unit);
                 }
-                let q_value = QuantityValue::ByServings(new_values);
+                let q_value = QuantityValue::ByServings{ values: new_values };
                 let unit = new_unit.expect("QuantityValue::ByServings empty");
                 (q_value, unit)
             }

--- a/src/model.rs
+++ b/src/model.rs
@@ -355,7 +355,7 @@ pub struct Component {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
 #[serde(rename_all = "camelCase")]
 pub enum ComponentKind {
-    Ingredient,
-    Cookware,
-    Timer,
+    IngredientKind,
+    CookwareKind,
+    TimerKind,
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -151,13 +151,13 @@ pub struct Step {
 #[serde(tag = "type", content = "value", rename_all = "camelCase")]
 pub enum Item {
     /// Just plain text
-    Text(String),
+    Text { value: String },
     /// A [Component]
-    Component(Component),
+    ItemComponent { value: Component },
     /// An inline quantity.
     ///
     /// The number inside is an index into [Recipe::inline_quantities].
-    InlineQuantity(usize),
+    InlineQuantity { value: usize },
 }
 
 /// A recipe ingredient

--- a/src/parser/quantity.rs
+++ b/src/parser/quantity.rs
@@ -357,7 +357,7 @@ mod tests {
         assert_eq!(
             q.value,
             QuantityValue::Single {
-                value: Located::new(Value::Number(100.0), 0..3),
+                value: Located::new(Value::Number { value: 100.0 }, 0..3),
                 auto_scale: None,
             }
         );
@@ -371,7 +371,7 @@ mod tests {
         assert_eq!(
             q.value,
             QuantityValue::Single {
-                value: Located::new(Value::Number(100.0), 0..3),
+                value: Located::new(Value::Number { value: 100.0 }, 0..3),
                 auto_scale: None
             }
         );
@@ -383,7 +383,7 @@ mod tests {
         assert_eq!(
             q.value,
             QuantityValue::Single {
-                value: Located::new(Value::Text("100 ml".into()), 0..6),
+                value: Located::new(Value::Text { value: "100 ml".into() }, 0..6),
                 auto_scale: None
             }
         );
@@ -398,9 +398,9 @@ mod tests {
         assert_eq!(
             q.value,
             QuantityValue::Many(vec![
-                Located::new(Value::Number(100.0), 0..3),
-                Located::new(Value::Number(200.0), 4..7),
-                Located::new(Value::Number(300.0), 8..11),
+                Located::new(Value::Number { value: 100.0 }, 0..3),
+                Located::new(Value::Number { value: 200.0 }, 4..7),
+                Located::new(Value::Number { value: 300.0 }, 8..11),
             ])
         );
         assert_eq!(s, Some((11..12).into()));
@@ -411,9 +411,9 @@ mod tests {
         assert_eq!(
             q.value,
             QuantityValue::Many(vec![
-                Located::new(Value::Number(100.0), 0..3),
-                Located::new(Value::Range(2.0..=3.0), 4..7),
-                Located::new(Value::Text("str".into()), 8..11),
+                Located::new(Value::Number { value: 100.0 }, 0..3),
+                Located::new(Value::Range { value: 2.0..=3.0 }, 4..7),
+                Located::new(Value::Text { value: "str".into() }, 8..11),
             ])
         );
         assert_eq!(s, Some((12..13).into()));
@@ -425,8 +425,8 @@ mod tests {
         assert_eq!(
             q.value,
             QuantityValue::Many(vec![
-                Located::new(Value::Number(100.0), 0..3),
-                Located::new(Value::Text("".into()), 4..4)
+                Located::new(Value::Number { value: 100.0 }, 0..3),
+                Located::new(Value::Text { value: "".into() }, 4..4)
             ])
         );
         assert_eq!(ctx.errors.len(), 1);
@@ -439,7 +439,7 @@ mod tests {
         assert_eq!(
             q.value,
             QuantityValue::Single {
-                value: Located::new(Value::Range(2.0..=3.0), 0..3),
+                value: Located::new(Value::Range { value: 2.0..=3.0 }, 0..3),
                 auto_scale: None
             }
         );
@@ -452,7 +452,7 @@ mod tests {
         assert_eq!(
             q.value,
             QuantityValue::Single {
-                value: Located::new(Value::Text("2-3".into()), 0..3),
+                value: Located::new(Value::Text { value: "2-3".into() }, 0..3),
                 auto_scale: None
             }
         );

--- a/src/parser/quantity.rs
+++ b/src/parser/quantity.rs
@@ -132,7 +132,7 @@ pub fn parse_quantity<'input>(
         _ => {
             line.consume_rest();
             let text = line.text(line.tokens().first().unwrap().span.start(), line.tokens());
-            let text_val = Value::Text(text.text_trimmed().into_owned());
+            let text_val = Value::Text { value: text.text_trimmed().into_owned() };
             value = ast::QuantityValue::Single {
                 value: Located::new(text_val, text.span()),
                 auto_scale: None,
@@ -229,7 +229,7 @@ fn text_value(tokens: &[Token], offset: usize, line: &mut LineParser) -> Value {
             help: None,
         });
     }
-    Value::Text(text.text_trimmed().into_owned())
+    Value::Text { value: text.text_trimmed().into_owned() }
 }
 
 fn numeric_value(tokens: &[Token], line: &LineParser) -> Option<Result<Value, ParserError>> {
@@ -252,20 +252,20 @@ fn numeric_value(tokens: &[Token], line: &LineParser) -> Option<Result<Value, Pa
 
     let r = match filtered_tokens.as_slice() {
         // int
-        &[t @ mt![int]] => int(t, line).map(Value::Number),
+        &[t @ mt![int]] => int(t, line).map(|v| { Value::Number { value: v }}),
         // float
-        &[t @ mt![float]] => float(t, line).map(Value::Number),
+        &[t @ mt![float]] => float(t, line).map(|v| { Value::Number { value: v }}),
         // mixed number
         &[i @ mt![int], a @ mt![int], mt![/], b @ mt![int]] => {
-            mixed_num(i, a, b, line).map(Value::Number)
+            mixed_num(i, a, b, line).map(|v| { Value::Number { value: v }})
         }
         // frac
-        &[a @ mt![int], mt![/], b @ mt![int]] => frac(a, b, line).map(Value::Number),
+        &[a @ mt![int], mt![/], b @ mt![int]] => frac(a, b, line).map(|v| { Value::Number { value: v }}),
         // range
         &[s @ mt![int | float], mt![-], e @ mt![int | float]]
             if line.extension(Extensions::RANGE_VALUES) =>
         {
-            range(s, e, line).map(Value::Range)
+            range(s, e, line).map(|v| { Value::Range { value: v }})
         }
         // other => text
         _ => return None,

--- a/src/quantity.rs
+++ b/src/quantity.rs
@@ -25,11 +25,11 @@ pub struct Quantity {
 #[serde(tag = "type", content = "value", rename_all = "camelCase")]
 pub enum QuantityValue {
     /// Cannot be scaled
-    Fixed(Value),
+    Fixed { value: Value },
     /// Scaling is linear to the number of servings
-    Linear(Value),
+    Linear { value: Value },
     /// Scaling is in defined steps of the number of servings
-    ByServings(Vec<Value>),
+    ByServings{ values: Vec<Value> },
 }
 
 /// Base value
@@ -69,8 +69,8 @@ impl QuantityValue {
     /// Checks if any of the possible values is text
     pub fn contains_text_value(&self) -> bool {
         match self {
-            QuantityValue::Fixed(v) | QuantityValue::Linear(v) => v.is_text(),
-            QuantityValue::ByServings(v) => v.iter().any(Value::is_text),
+            QuantityValue::Fixed{ value } |  QuantityValue::Linear{ value } => value.is_text(),
+            QuantityValue::ByServings { values } => values.iter().any(Value::is_text),
         }
     }
 }
@@ -189,14 +189,14 @@ impl QuantityValue {
                 value,
                 auto_scale: None,
                 ..
-            } => Self::Fixed(value.take()),
+            } => Self::Fixed { value: value.take() },
             ast::QuantityValue::Single {
                 value,
                 auto_scale: Some(_),
                 ..
-            } => Self::Linear(value.take()),
+            } => Self::Linear{ value: value.take() },
             ast::QuantityValue::Many(v) => {
-                Self::ByServings(v.into_iter().map(crate::located::Located::take).collect())
+                Self::ByServings { values: v.into_iter().map(crate::located::Located::take).collect() }
             }
         }
     }
@@ -215,12 +215,12 @@ impl Display for Quantity {
 impl Display for QuantityValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Fixed(v) | Self::Linear(v) => v.fmt(f),
-            Self::ByServings(v) => {
-                for value in &v[..v.len() - 1] {
+            Self::Fixed { value } | Self::Linear { value } => value.fmt(f),
+            Self::ByServings{ values } => {
+                for value in &values[..values.len() - 1] {
                     write!(f, "{}|", value)?;
                 }
-                write!(f, "{}", v.last().unwrap())
+                write!(f, "{}", values.last().unwrap())
             }
         }
     }
@@ -398,15 +398,15 @@ pub struct NotScaled(pub QuantityValue);
 impl QuantityValue {
     pub(crate) fn extract_value(&self) -> Result<&Value, NotScaled> {
         match self {
-            Self::Fixed(v) => Ok(v),
-            Self::Linear(_) | Self::ByServings(_) => Err(NotScaled(self.to_owned())),
+            Self::Fixed { value } => Ok(value),
+            Self::Linear{ .. } | Self::ByServings { .. } => Err(NotScaled(self.to_owned())),
         }
     }
 
     /// Try adding two [QuantityValue]s.
     pub fn try_add(&self, rhs: &Self) -> Result<Self, QuantityAddError> {
         let value = self.extract_value()?.try_add(rhs.extract_value()?)?;
-        Ok(QuantityValue::Fixed(value))
+        Ok(QuantityValue::Fixed { value })
     }
 }
 

--- a/src/scale.rs
+++ b/src/scale.rs
@@ -266,9 +266,9 @@ impl QuantityValue {
 impl Value {
     fn scale(&self, factor: f64) -> Result<Value, ScaleError> {
         match self.clone() {
-            Value::Number(n) => Ok(Value::Number(n * factor)),
-            Value::Range(r) => Ok(Value::Range(r.start() * factor..=r.end() * factor)),
-            v @ Value::Text(_) => Err(TextValueError(v).into()),
+            Value::Number { value: n } => Ok(Value::Number { value: n * factor }),
+            Value::Range { value: r } => Ok(Value::Range { value: r.start() * factor..=r.end() * factor }),
+            v @ Value::Text { value: _ } => Err(TextValueError(v).into()),
         }
     }
 }

--- a/src/scale.rs
+++ b/src/scale.rs
@@ -231,11 +231,11 @@ fn default_scale_many<'a, T: 'a>(
 impl QuantityValue {
     fn scale(self, target: ScaleTarget) -> Result<(QuantityValue, ScaleOutcome), ScaleError> {
         let (value, outcome) = match self {
-            Self::Fixed(v) => (v, ScaleOutcome::Fixed),
-            Self::Linear(v) => (v.scale(target.factor())?, ScaleOutcome::Scaled),
-            Self::ByServings(ref v) => {
+            Self::Fixed { value } => (value, ScaleOutcome::Fixed),
+            Self::Linear { value } => (value.scale(target.factor())?, ScaleOutcome::Scaled),
+            Self::ByServings { ref values } => {
                 if let Some(index) = target.index {
-                    let Some(value) = v.get(index) else {
+                    let Some(value) = values.get(index) else {
                         return Err(ScaleError::NotDefined { target, value: self });
                     };
                     (value.clone(), ScaleOutcome::Scaled)
@@ -247,18 +247,18 @@ impl QuantityValue {
                 }
             }
         };
-        Ok((Self::Fixed(value), outcome))
+        Ok((Self::Fixed { value }, outcome))
     }
 
     fn default_scale(self) -> Self {
         match self {
-            v @ Self::Fixed(_) => v,
-            Self::Linear(v) => Self::Fixed(v),
-            Self::ByServings(v) => Self::Fixed(
-                v.first()
+            v @ Self::Fixed { .. } => v,
+            Self::Linear { value } => Self::Fixed { value },
+            Self::ByServings { values } => Self::Fixed {
+                value: values.first()
                     .expect("scalable value servings list empty")
                     .clone(),
-            ),
+            },
         }
     }
 }

--- a/tests/canonical.rs
+++ b/tests/canonical.rs
@@ -154,7 +154,7 @@ fn compare_items(expected: &Yaml, got: &cooklang::model::Item, recipe: &cooklang
 
 fn compare_value(expected: &Yaml, got: &QuantityValue) {
     let value = match got {
-        QuantityValue::Fixed(v) => v,
+        QuantityValue::Fixed{ value } => v,
         _ => {
             panic!("scalable values not supported by cooklang currently");
         }

--- a/tests/canonical.rs
+++ b/tests/canonical.rs
@@ -76,8 +76,8 @@ fn join_text_items(items: &[cooklang::model::Item]) -> Vec<cooklang::model::Item
 
     let mut out = Vec::new();
     for item in items {
-        if let Text(current) = item {
-            if let Some(Text(last)) = out.last_mut() {
+        if let Text { value: current } = item {
+            if let Some(Text { value: last }) = out.last_mut() {
                 last.push_str(&current);
                 continue;
             }
@@ -93,12 +93,12 @@ fn compare_items(expected: &Yaml, got: &cooklang::model::Item, recipe: &cooklang
     let tyype = expected["type"].as_str().unwrap();
 
     match got {
-        Item::Text(text) => {
+        Item::Text { value: text } => {
             assert_eq!(tyype, "text");
             assert_eq!(expected["value"].as_str().unwrap(), text);
         }
-        Item::Component(component) => match component.kind {
-            ComponentKind::Ingredient => {
+        Item::ItemComponent { value: component } => match component.kind {
+            ComponentKind::IngredientKind => {
                 let i = &recipe.ingredients[component.index];
                 assert_eq!(tyype, "ingredient");
                 assert!(i.alias.is_none());
@@ -120,7 +120,7 @@ fn compare_items(expected: &Yaml, got: &cooklang::model::Item, recipe: &cooklang
                     None => assert_eq!("some", expected["quantity"].as_str().unwrap()),
                 }
             }
-            ComponentKind::Cookware => {
+            ComponentKind::CookwareKind => {
                 let c = &recipe.cookware[component.index];
                 assert_eq!(tyype, "cookware");
                 assert_eq!(c.name, expected["name"].as_str().unwrap());
@@ -129,7 +129,7 @@ fn compare_items(expected: &Yaml, got: &cooklang::model::Item, recipe: &cooklang
                     None => assert_eq!(expected["quantity"].as_i64().unwrap(), 1),
                 }
             }
-            ComponentKind::Timer => {
+            ComponentKind::TimerKind => {
                 let t = &recipe.timers[component.index];
                 assert_eq!(tyype, "timer");
                 match &t.name {
@@ -154,13 +154,13 @@ fn compare_items(expected: &Yaml, got: &cooklang::model::Item, recipe: &cooklang
 
 fn compare_value(expected: &Yaml, got: &QuantityValue) {
     let value = match got {
-        QuantityValue::Fixed{ value } => v,
+        QuantityValue::Fixed { value: v } => v,
         _ => {
             panic!("scalable values not supported by cooklang currently");
         }
     };
     match value {
-        Value::Number(n) => {
+        Value::Number { value: n } => {
             assert_eq!(
                 *n as f64,
                 expected
@@ -170,7 +170,7 @@ fn compare_value(expected: &Yaml, got: &QuantityValue) {
                     .unwrap()
             )
         }
-        Value::Range(_) => panic!("Unexpected range value"),
-        Value::Text(t) => assert_eq!(t, expected.as_str().unwrap()),
+        Value::Range { value: _ } => panic!("Unexpected range value"),
+        Value::Text { value: t } => assert_eq!(t, expected.as_str().unwrap()),
     };
 }


### PR DESCRIPTION
First portion of changes required for UniFFI compatibility:
* Changed QuantityValue, Item, Value, ComponentKind enums to use named argument definition instead of tuples
* Added suffix ...Kind to ComponentKind enum variants to avoid type name clashes in UniFFI.