### PR TITLE
Tiny typo fix in define ingredient warning

### DIFF
--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -82,7 +82,7 @@ pub enum AnalysisWarning {
     #[error("Ignoring unknown special metadata key: {key}")]
     UnknownSpecialMetadataKey { key: Located<String> },
 
-    #[error("Ingoring text in define ingredients mode")]
+    #[error("Ignoring text in define ingredients mode")]
     TextDefiningIngredients { text_span: Span },
 
     #[error("Text value in reference prevents calculating total amount")]


### PR DESCRIPTION
Just a small typo I noticed, would it be okay to merge?