### PR TITLE
Better values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,5 +47,9 @@ aisle = ["dep:pest", "dep:pest_derive"]
 name = "parse"
 harness = false
 
+[[bench]]
+name = "convert"
+harness = false
+
 [workspace]
 members = [".", "playground", "bindings"]

--- a/benches/convert.rs
+++ b/benches/convert.rs
@@ -1,0 +1,68 @@
+use cooklang::{
+    convert::{ConvertTo, System},
+    Converter, Quantity, Value,
+};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+fn imperial(c: &mut Criterion) {
+    let mut group = c.benchmark_group("imperial conversions (fractions)");
+    let converter = Converter::default();
+
+    let input = vec![
+        (1.5, "tsp"),
+        (2.0, "tsp"),
+        (3.0, "tsp"),
+        (3.5, "tbsp"),
+        (300.0, "ml"),
+        (1.5, "l"),
+        (20.0, "g"),
+    ]
+    .into_iter()
+    .map(|(v, u)| Quantity::new(Value::Number(v.into()), Some(u.to_string())))
+    .collect::<Vec<_>>();
+
+    let input = black_box(input);
+
+    group.bench_function("default-converter", |b| {
+        b.iter(|| {
+            let mut input = input.clone();
+            for q in &mut input {
+                let _ = q.convert(ConvertTo::Best(System::Imperial), &converter);
+                let _ = q.fit(&converter);
+            }
+        })
+    });
+}
+
+fn metric(c: &mut Criterion) {
+    let mut group = c.benchmark_group("metric conversions (no fractions)");
+    let converter = Converter::default();
+
+    let input = vec![
+        (1.5, "tsp"),
+        (2.0, "tsp"),
+        (3.0, "tsp"),
+        (3.5, "tbsp"),
+        (300.0, "ml"),
+        (1.5, "l"),
+        (20.0, "g"),
+    ]
+    .into_iter()
+    .map(|(v, u)| Quantity::new(Value::Number(v.into()), Some(u.to_string())))
+    .collect::<Vec<_>>();
+
+    let input = black_box(input);
+
+    group.bench_function("default-converter", |b| {
+        b.iter(|| {
+            let mut input = input.clone();
+            for q in &mut input {
+                let _ = q.convert(ConvertTo::Best(System::Metric), &converter);
+                let _ = q.fit(&converter);
+            }
+        })
+    });
+}
+
+criterion_group!(benches, imperial, metric);
+criterion_main!(benches);

--- a/bindings/src/lib.rs
+++ b/bindings/src/lib.rs
@@ -1,12 +1,12 @@
-use std::collections::HashMap;
 use cooklang::analysis::{parse_events, RecipeContent};
-use cooklang::model::{Item as ModelItem};
-use cooklang::parser::{PullParser};
+use cooklang::model::Item as ModelItem;
+use cooklang::parser::PullParser;
 use cooklang::quantity::{
     Quantity as ModelQuantity, ScalableValue as ModelScalableValue, Value as ModelValue,
 };
 use cooklang::Converter;
 use cooklang::Extensions;
+use std::collections::HashMap;
 
 #[derive(uniffi::Record, Debug)]
 pub struct CooklangRecipe {
@@ -86,30 +86,29 @@ impl Amountable for ModelScalableValue {
 
 fn extract_quantity(value: &ModelScalableValue) -> Value {
     match value {
-        ModelScalableValue::Fixed { value } => extract_value(value),
-        ModelScalableValue::Linear { value } => extract_value(value),
-        ModelScalableValue::ByServings { values } => extract_value(values.first().unwrap()),
+        ModelScalableValue::Fixed(value) => extract_value(value),
+        ModelScalableValue::Linear(value) => extract_value(value),
+        ModelScalableValue::ByServings(values) => extract_value(values.first().unwrap()),
     }
 }
 
 fn extract_value(value: &ModelValue) -> Value {
     match value {
-        ModelValue::Number { value } => Value::Number { value: *value },
-        ModelValue::Range { value } => Value::Range {
+        ModelValue::Number(value) => Value::Number { value: *value },
+        ModelValue::Range(value) => Value::Range {
             start: *value.start(),
             end: *value.end(),
         },
-        ModelValue::Text { value } => Value::Text {
+        ModelValue::Text(value) => Value::Text {
             value: value.to_string(),
         },
     }
 }
 
-
 fn into_item(item: ModelItem, recipe: &RecipeContent) -> Item {
     match item {
         ModelItem::Text { value } => Item::Text { value },
-        ModelItem::ItemIngredient { index } => {
+        ModelItem::Ingredient { index } => {
             let ingredient = &recipe.ingredients[index];
 
             Item::Ingredient {
@@ -120,9 +119,9 @@ fn into_item(item: ModelItem, recipe: &RecipeContent) -> Item {
                     None
                 },
             }
-        },
+        }
 
-        ModelItem::ItemCookware { index } => {
+        ModelItem::Cookware { index } => {
             let cookware = &recipe.cookware[index];
             Item::Cookware {
                 name: cookware.name.clone(),
@@ -132,9 +131,9 @@ fn into_item(item: ModelItem, recipe: &RecipeContent) -> Item {
                     None
                 },
             }
-        },
+        }
 
-        ModelItem::ItemTimer { index } => {
+        ModelItem::Timer { index } => {
             let timer = &recipe.timers[index];
 
             Item::Timer {
@@ -145,10 +144,10 @@ fn into_item(item: ModelItem, recipe: &RecipeContent) -> Item {
                     None
                 },
             }
-        },
+        }
 
         // returning an empty block of text as it's not supported by the spec
-        ModelItem::InlineQuantity { .. } => Item::Text {
+        ModelItem::InlineQuantity { index: _ } => Item::Text {
             value: "".to_string(),
         },
     }
@@ -218,7 +217,6 @@ pub fn parse_metadata(input: String) -> CooklangMetadata {
 
     let parser = PullParser::new(&input, extensions);
 
-
     let result = parse_events(parser.into_meta_iter(), extensions, &converter, None)
         .map(|c| c.metadata.map)
         .take_output()
@@ -241,7 +239,7 @@ mod tests {
 
     #[test]
     fn parse() {
-        use crate::{parse, Item, Amount, Value};
+        use crate::{parse, Amount, Item, Value};
 
         let recipe = parse(
             r#"
@@ -253,12 +251,16 @@ a test @step @salt{1%mg} more text
         assert_eq!(
             recipe.steps.into_iter().nth(0).unwrap().items,
             vec![
-                Item::Text { value: "a test ".to_string() },
+                Item::Text {
+                    value: "a test ".to_string()
+                },
                 Item::Ingredient {
                     name: "step".to_string(),
                     amount: None
                 },
-                Item::Text { value: " ".to_string() },
+                Item::Text {
+                    value: " ".to_string()
+                },
                 Item::Ingredient {
                     name: "salt".to_string(),
                     amount: Some(Amount {
@@ -275,7 +277,7 @@ a test @step @salt{1%mg} more text
 
     #[test]
     fn parse_metadata() {
-        use crate::{parse_metadata};
+        use crate::parse_metadata;
         use std::collections::HashMap;
 
         let metadata = parse_metadata(

--- a/bindings/src/lib.rs
+++ b/bindings/src/lib.rs
@@ -94,10 +94,10 @@ fn extract_quantity(value: &ModelScalableValue) -> Value {
 
 fn extract_value(value: &ModelValue) -> Value {
     match value {
-        ModelValue::Number(value) => Value::Number { value: *value },
-        ModelValue::Range(value) => Value::Range {
-            start: *value.start(),
-            end: *value.end(),
+        ModelValue::Number(num) => Value::Number { value: num.value() },
+        ModelValue::Range { start, end } => Value::Range {
+            start: start.value(),
+            end: end.value(),
         },
         ModelValue::Text(value) => Value::Text {
             value: value.to_string(),

--- a/src/analysis/ast_walker.rs
+++ b/src/analysis/ast_walker.rs
@@ -879,7 +879,7 @@ fn find_temperature<'a>(text: &'a str, re: &Regex) -> Option<(&'a str, Quantity<
     let value = caps[1].replace(',', ".").parse::<f64>().ok()?;
     let unit = caps.get(3).unwrap().range();
     let unit_text = text[unit].to_string();
-    let temperature = Quantity::new(Value::Number(value), Some(unit_text));
+    let temperature = Quantity::new(Value::Number(value.into()), Some(unit_text));
 
     let range = caps.get(0).unwrap().range();
     let (before, after) = (&text[..range.start], &text[range.end..]);

--- a/src/analysis/ast_walker.rs
+++ b/src/analysis/ast_walker.rs
@@ -282,13 +282,13 @@ impl<'i, 'c> RecipeCollector<'i, 'c> {
                         continue; // ignore component
                     }
                     let new_component = match item {
-                        Event::Ingredient(i) => Item::ItemIngredient {
+                        Event::Ingredient(i) => Item::Ingredient {
                             index: self.ingredient(i),
                         },
-                        Event::Cookware(c) => Item::ItemCookware {
+                        Event::Cookware(c) => Item::Cookware {
                             index: self.cookware(c),
                         },
-                        Event::Timer(t) => Item::ItemTimer {
+                        Event::Timer(t) => Item::Timer {
                             index: self.timer(t),
                         },
                         _ => unreachable!(),
@@ -481,7 +481,7 @@ impl<'i, 'c> RecipeCollector<'i, 'c> {
                         help,
                     });
                 }
-                IngredientRelation::reference(val, IngredientReferenceTarget::StepTarget)
+                IngredientRelation::reference(val, IngredientReferenceTarget::Step)
             }
             (Step, Relative) => {
                 let index = self
@@ -495,7 +495,7 @@ impl<'i, 'c> RecipeCollector<'i, 'c> {
                     .map(|(index, _)| index);
                 match index {
                     Some(index) => {
-                        IngredientRelation::reference(index, IngredientReferenceTarget::StepTarget)
+                        IngredientRelation::reference(index, IngredientReferenceTarget::Step)
                     }
                     None => {
                         let help = match self.step_counter {
@@ -529,7 +529,7 @@ impl<'i, 'c> RecipeCollector<'i, 'c> {
                         help,
                     });
                 }
-                IngredientRelation::reference(val, IngredientReferenceTarget::SectionTarget)
+                IngredientRelation::reference(val, IngredientReferenceTarget::Section)
             }
             (Section, Relative) => {
                 if val > self.content.sections.len() {
@@ -549,7 +549,7 @@ impl<'i, 'c> RecipeCollector<'i, 'c> {
                     });
                 }
                 let index = self.content.sections.len().saturating_sub(val);
-                IngredientRelation::reference(index, IngredientReferenceTarget::SectionTarget)
+                IngredientRelation::reference(index, IngredientReferenceTarget::Section)
             }
         };
         Ok(relation)
@@ -699,10 +699,8 @@ impl<'i, 'c> RecipeCollector<'i, 'c> {
 
         if is_ingredient && self.auto_scale_ingredients {
             match v {
-                ScalableValue::Fixed { value } if !value.is_text() => {
-                    v = ScalableValue::Linear { value }
-                }
-                ScalableValue::Linear { .. } => {
+                ScalableValue::Fixed(value) if !value.is_text() => v = ScalableValue::Linear(value),
+                ScalableValue::Linear(_) => {
                     self.ctx.warn(AnalysisWarning::RedundantAutoScaleMarker {
                         quantity_span: Span::new(value_span.end(), value_span.end() + 1),
                     });
@@ -828,10 +826,8 @@ impl RefComponent for Ingredient<ScalableValue> {
     }
 
     fn set_reference(&mut self, references_to: usize) {
-        self.relation = IngredientRelation::reference(
-            references_to,
-            IngredientReferenceTarget::IngredientTarget,
-        );
+        self.relation =
+            IngredientRelation::reference(references_to, IngredientReferenceTarget::Ingredient);
     }
 
     fn set_referenced_from(all: &mut [Self], references_to: usize) {
@@ -883,7 +879,7 @@ fn find_temperature<'a>(text: &'a str, re: &Regex) -> Option<(&'a str, Quantity<
     let value = caps[1].replace(',', ".").parse::<f64>().ok()?;
     let unit = caps.get(3).unwrap().range();
     let unit_text = text[unit].to_string();
-    let temperature = Quantity::new(Value::Number { value }, Some(unit_text));
+    let temperature = Quantity::new(Value::Number(value), Some(unit_text));
 
     let range = caps.get(0).unwrap().range();
     let (before, after) = (&text[..range.start], &text[range.end..]);

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -193,7 +193,7 @@ impl Recover for QuantityValue {
 
 impl Recover for Value {
     fn recover() -> Self {
-        Self::Number(1.0)
+        1.0.into()
     }
 }
 

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -55,9 +55,9 @@ pub enum Block<'a> {
 pub enum Item<'a> {
     /// Plain text
     Text(Text<'a>),
-    Ingredient(Located<Ingredient<'a>>),
-    Cookware(Located<Cookware<'a>>),
-    Timer(Located<Timer<'a>>),
+    Ingredient(Box<Located<Ingredient<'a>>>),
+    Cookware(Box<Located<Cookware<'a>>>),
+    Timer(Box<Located<Timer<'a>>>),
 }
 
 impl Item<'_> {

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -193,7 +193,7 @@ impl Recover for QuantityValue {
 
 impl Recover for Value {
     fn recover() -> Self {
-        Self::Number { value: 1.0 }
+        Self::Number(1.0)
     }
 }
 

--- a/src/convert/mod.rs
+++ b/src/convert/mod.rs
@@ -541,8 +541,8 @@ impl<'a> From<&'a Arc<Unit>> for ConvertTo<'a> {
 impl From<ConvertValue> for Value {
     fn from(value: ConvertValue) -> Self {
         match value {
-            ConvertValue::Number(n) => Self::Number { value: n },
-            ConvertValue::Range(r) => Self::Range { value: r },
+            ConvertValue::Number(n) => Self::Number(n),
+            ConvertValue::Range(r) => Self::Range(r),
         }
     }
 }
@@ -551,9 +551,9 @@ impl TryFrom<Value> for ConvertValue {
     type Error = ConvertError;
     fn try_from(value: Value) -> Result<Self, Self::Error> {
         let value = match value {
-            Value::Number { value: n } => ConvertValue::Number(n),
-            Value::Range { value: r } => ConvertValue::Range(r),
-            Value::Text { value: t } => return Err(ConvertError::TextValue(t)),
+            Value::Number(n) => ConvertValue::Number(n),
+            Value::Range(r) => ConvertValue::Range(r),
+            Value::Text(t) => return Err(ConvertError::TextValue(t)),
         };
         Ok(value)
     }

--- a/src/convert/mod.rs
+++ b/src/convert/mod.rs
@@ -204,7 +204,6 @@ struct Fractions {
 #[derive(Debug, Clone, Copy)]
 pub struct FractionsConfig {
     pub enabled: bool,
-    pub mixed_value: bool,
     pub accuracy: f32,
     pub max_denominator: u32,
     pub max_whole: u32,
@@ -214,7 +213,6 @@ impl Default for FractionsConfig {
     fn default() -> Self {
         Self {
             enabled: false,
-            mixed_value: true,
             accuracy: 0.05,
             max_denominator: 4,
             max_whole: u32::MAX,
@@ -447,13 +445,7 @@ impl ScaledQuantity {
         converter: &Converter,
     ) -> Result<bool, ConvertError> {
         let approx = |val: f64, cfg: FractionsConfig| {
-            Number::new_approx(
-                val,
-                cfg.mixed_value,
-                cfg.accuracy,
-                cfg.max_denominator,
-                cfg.max_whole,
-            )
+            Number::new_approx(val, cfg.accuracy, cfg.max_denominator, cfg.max_whole)
         };
 
         let Some(system) = unit.system else {
@@ -531,24 +523,10 @@ impl ScaledQuantity {
         }
 
         match &mut self.value {
-            Value::Number(n) => n.to_fraction(
-                cfg.mixed_value,
-                cfg.accuracy,
-                cfg.max_denominator,
-                cfg.max_whole,
-            ),
+            Value::Number(n) => n.to_fraction(cfg.accuracy, cfg.max_denominator, cfg.max_whole),
             Value::Range { start, end } => {
-                start.to_fraction(
-                    cfg.mixed_value,
-                    cfg.accuracy,
-                    cfg.max_denominator,
-                    cfg.max_whole,
-                ) || end.to_fraction(
-                    cfg.mixed_value,
-                    cfg.accuracy,
-                    cfg.max_denominator,
-                    cfg.max_whole,
-                )
+                start.to_fraction(cfg.accuracy, cfg.max_denominator, cfg.max_whole)
+                    || end.to_fraction(cfg.accuracy, cfg.max_denominator, cfg.max_whole)
             }
             Value::Text(_) => false,
         }

--- a/src/convert/mod.rs
+++ b/src/convert/mod.rs
@@ -541,8 +541,11 @@ impl<'a> From<&'a Arc<Unit>> for ConvertTo<'a> {
 impl From<ConvertValue> for Value {
     fn from(value: ConvertValue) -> Self {
         match value {
-            ConvertValue::Number(n) => Self::Number(n),
-            ConvertValue::Range(r) => Self::Range(r),
+            ConvertValue::Number(n) => Self::Number(n.into()),
+            ConvertValue::Range(r) => Self::Range {
+                start: (*r.start()).into(),
+                end: (*r.end()).into(),
+            },
         }
     }
 }
@@ -551,8 +554,8 @@ impl TryFrom<Value> for ConvertValue {
     type Error = ConvertError;
     fn try_from(value: Value) -> Result<Self, Self::Error> {
         let value = match value {
-            Value::Number(n) => ConvertValue::Number(n),
-            Value::Range(r) => ConvertValue::Range(r),
+            Value::Number(n) => ConvertValue::Number(n.value()),
+            Value::Range { start, end } => ConvertValue::Range(start.value()..=end.value()),
             Value::Text(t) => return Err(ConvertError::TextValue(t)),
         };
         Ok(value)

--- a/src/convert/mod.rs
+++ b/src/convert/mod.rs
@@ -696,7 +696,7 @@ impl BestConversions {
             .0
             .iter()
             .rev()
-            .find(|(th, _)| norm >= *th)
+            .find(|(th, _)| norm >= (th - 0.001))
             .or_else(|| self.0.first())
             .map(|&(_, id)| id)?;
         Some(Arc::clone(&converter.all_units[best_id]))

--- a/src/convert/mod.rs
+++ b/src/convert/mod.rs
@@ -413,7 +413,12 @@ impl ScaledQuantity {
         let value = ConvertValue::try_from(&self.value)?;
 
         let (new_value, new_unit) = converter.convert(value, unit, to)?;
-        *self = Quantity::with_known_unit(new_value.into(), new_unit);
+        *self = Quantity::with_known_unit(new_value.into(), Arc::clone(&new_unit));
+        if matches!(to, ConvertTo::Unit(_)) {
+            self.try_fraction(converter);
+        } else if converter.should_fit_fraction(&new_unit) {
+            self.fit_fraction(&new_unit, converter)?;
+        }
         Ok(())
     }
 

--- a/src/convert/units_file.rs
+++ b/src/convert/units_file.rs
@@ -179,7 +179,7 @@ pub struct Extend {
 /// This is important in, for example, the case of symbols. The first symbol
 /// is the one that will be used for formatting.
 #[derive(Debug, Default, Deserialize, Clone, Copy, PartialEq, Eq)]
-#[serde(rename = "snake_case")]
+#[serde(rename_all = "snake_case")]
 pub enum Precedence {
     /// The list will be added before the current ones (*higher priority*)
     #[default]
@@ -222,7 +222,7 @@ pub struct QuantityGroup {
 /// set a unit's system in either, this enum, in [`Units`] or in both (but it
 /// has to match).
 #[derive(Debug, Deserialize, Clone)]
-#[serde(untagged, rename = "snake_case", deny_unknown_fields)]
+#[serde(untagged, deny_unknown_fields)]
 pub enum BestUnits {
     /// List without system information
     Unified(Vec<String>),
@@ -240,7 +240,7 @@ pub enum BestUnits {
 /// set a unit's system in either, this enum, in [`BestUnits`] or in both (but it
 /// has to match).
 #[derive(Debug, Deserialize, Clone)]
-#[serde(untagged, rename = "snake_case", deny_unknown_fields)]
+#[serde(untagged, deny_unknown_fields)]
 pub enum Units {
     /// List without [`System`] information
     Unified(Vec<UnitEntry>),

--- a/src/convert/units_file.rs
+++ b/src/convert/units_file.rs
@@ -126,7 +126,6 @@ impl FractionsWrapper {
 #[serde(default)]
 pub struct FractionsConfigHelper {
     pub enabled: Option<bool>,
-    pub mixed_value: Option<bool>,
     pub accuracy: Option<f32>,
     pub max_denominator: Option<u32>,
     pub max_whole: Option<u32>,
@@ -136,7 +135,6 @@ impl FractionsConfigHelper {
     pub fn merge(self, parent: FractionsConfigHelper) -> Self {
         Self {
             enabled: self.enabled.or(parent.enabled),
-            mixed_value: self.mixed_value.or(parent.mixed_value),
             accuracy: self.accuracy.or(parent.accuracy),
             max_denominator: self.max_denominator.or(parent.max_denominator),
             max_whole: self.max_whole.or(parent.max_whole),
@@ -147,7 +145,6 @@ impl FractionsConfigHelper {
         let d = FractionsConfig::default();
         FractionsConfig {
             enabled: self.enabled.unwrap_or(d.enabled),
-            mixed_value: self.mixed_value.unwrap_or(d.mixed_value),
             accuracy: self.accuracy.unwrap_or(d.accuracy).clamp(0.0, 1.0),
             max_denominator: self
                 .max_denominator

--- a/src/model.rs
+++ b/src/model.rs
@@ -342,15 +342,13 @@ pub struct IngredientRelation {
 ///
 /// This is obtained from [`IngredientRelation::references_to`]
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone, Copy)]
+#[serde(rename_all = "camelCase")]
 pub enum IngredientReferenceTarget {
     /// Ingredient definition
-    #[serde(rename = "ingredient")]
     Ingredient,
     /// Step in the current section
-    #[serde(rename = "step")]
     Step,
     /// Section in the current recipe
-    #[serde(rename = "section")]
     Section,
 }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -339,9 +339,9 @@ pub fn build_ast<'input>(
                 }
             }
             Event::Text(t) => items.push(ast::Item::Text(t)),
-            Event::Ingredient(c) => items.push(ast::Item::Ingredient(c)),
-            Event::Cookware(c) => items.push(ast::Item::Cookware(c)),
-            Event::Timer(c) => items.push(ast::Item::Timer(c)),
+            Event::Ingredient(c) => items.push(ast::Item::Ingredient(Box::new(c))),
+            Event::Cookware(c) => items.push(ast::Item::Cookware(Box::new(c))),
+            Event::Timer(c) => items.push(ast::Item::Timer(Box::new(c))),
             Event::Error(e) => ctx.error(e),
             Event::Warning(w) => ctx.warn(w),
         }

--- a/src/parser/quantity.rs
+++ b/src/parser/quantity.rs
@@ -286,7 +286,12 @@ fn mixed_num(i: Token, a: Token, b: Token, bp: &BlockParser) -> Result<Number, P
     let Number::Fraction { num, den, .. } = frac(a, b, bp)? else {
         unreachable!()
     };
-    Ok(Number::Fraction { whole: i, num, den })
+    Ok(Number::Fraction {
+        whole: i,
+        num,
+        den,
+        err: 0.0,
+    })
 }
 
 fn frac(a: Token, b: Token, line: &BlockParser) -> Result<Number, ParserError> {
@@ -301,6 +306,7 @@ fn frac(a: Token, b: Token, line: &BlockParser) -> Result<Number, ParserError> {
             whole: 0.0,
             num: a,
             den: b,
+            err: 0.0,
         })
     }
 }
@@ -530,9 +536,16 @@ mod tests {
         let Value::Number(num) = value else {
             panic!("not number")
         };
-        let Number::Fraction { whole, num, den } = num else {
+        let Number::Fraction {
+            whole,
+            num,
+            den,
+            err,
+        } = num
+        else {
             panic!("not fraction")
         };
+        assert_eq!(err, 0.0);
         (whole, num, den)
     }
 }

--- a/src/quantity.rs
+++ b/src/quantity.rs
@@ -68,12 +68,12 @@ pub enum Value {
 /// assert_eq!(num.to_string(), "14");
 /// let num = Number::Regular(14.57893);
 /// assert_eq!(num.to_string(), "14.579");
-/// let num = Number::Fraction { whole: 0.0, num: 1.0, den: 2.0 };
+/// let num = Number::Fraction { whole: 0.0, num: 1.0, den: 2.0, err: 0.0 };
 /// assert_eq!(num.to_string(), "1/2");
 /// assert_eq!(num.value(), 0.5);
-/// let num = Number::Fraction { whole: 2.0, num: 1.0, den: 2.0 };
+/// let num = Number::Fraction { whole: 2.0, num: 1.0, den: 2.0, err: 0.001 };
 /// assert_eq!(num.to_string(), "2 1/2");
-/// assert_eq!(num.value(), 2.5);
+/// assert_eq!(num.value(), 2.501);
 /// ```
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[serde(tag = "type", content = "value", rename_all = "camelCase")]

--- a/src/quantity.rs
+++ b/src/quantity.rs
@@ -76,6 +76,7 @@ pub enum Value {
 /// assert_eq!(num.value(), 2.5);
 /// ```
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(tag = "type", content = "value", rename_all = "camelCase")]
 pub enum Number {
     /// A regular number
     Regular(f64),

--- a/src/quantity.rs
+++ b/src/quantity.rs
@@ -797,26 +797,21 @@ impl Number {
     /// This creates a fraction if there's any error or an exact whole regular number.
     /// That regular number is never 0 with an error, but can be 0 exact.
     ///
-    /// `allow_mixed` allows things like `2 1/2`
-    ///
     /// `max_err` is a value between 0 and 1 representing the error percent.
     ///
     /// `max_den` is the maximum denominator. The denominator is one a list of
     /// "common" fractions: 2, 3, 4, 5, 8, 10, 16, 32, 64. 64 is the max.
     ///
+    /// `max_whole` determines the maximum value of the intenger. Setting this to
+    /// 0 only allows fractions < 1.
+    ///
     /// # Panics
     /// - If `max_err > 1` or `max_err < 0`.
     /// - If `max_den > 64`
-    pub fn new_approx(
-        value: f64,
-        allow_mixed: bool,
-        accuracy: f32,
-        max_den: u32,
-        max_whole: u32,
-    ) -> Option<Self> {
+    pub fn new_approx(value: f64, accuracy: f32, max_den: u32, max_whole: u32) -> Option<Self> {
         assert!((0.0..=1.0).contains(&accuracy));
         assert!(max_den <= 64);
-        if (!allow_mixed && value > 1.0) || value <= 0.0 || !value.is_finite() {
+        if (max_whole == 0 && value > 1.0) || value <= 0.0 || !value.is_finite() {
             return None;
         }
 
@@ -864,14 +859,8 @@ impl Number {
         })
     }
 
-    pub fn to_fraction(
-        &mut self,
-        allow_mixed: bool,
-        accuracy: f32,
-        max_den: u32,
-        max_whole: u32,
-    ) -> bool {
-        match Self::new_approx(self.value(), allow_mixed, accuracy, max_den, max_whole) {
+    pub fn to_fraction(&mut self, accuracy: f32, max_den: u32, max_whole: u32) -> bool {
+        match Self::new_approx(self.value(), accuracy, max_den, max_whole) {
             Some(f) => {
                 *self = f;
                 true

--- a/src/quantity.rs
+++ b/src/quantity.rs
@@ -824,7 +824,7 @@ impl Number {
             return None;
         }
 
-        if 1.0 - decimal < max_err && (whole as u32) < max_whole {
+        if (1.0 - decimal < max_err) && (whole as u32) < max_whole {
             return Some(Self::Fraction {
                 whole: whole + 1.0,
                 num: 0.0,

--- a/src/scale.rs
+++ b/src/scale.rs
@@ -270,8 +270,12 @@ impl Scale for ScalableValue {
 
 fn linear_scale(value: Value, factor: f64) -> Result<Value, ScaleError> {
     match value {
-        Value::Number(n) => Ok(Value::Number(n * factor)),
-        Value::Range(r) => Ok(Value::Range(r.start() * factor..=r.end() * factor)),
+        Value::Number(n) => Ok(Value::Number((n.value() * factor).into())),
+        Value::Range { start, end } => {
+            let start = (start.value() * factor).into();
+            let end = (end.value() * factor).into();
+            Ok(Value::Range { start, end })
+        }
         v @ Value::Text(_) => Err(TextValueError(v).into()),
     }
 }

--- a/src/scale.rs
+++ b/src/scale.rs
@@ -223,12 +223,12 @@ impl Scale for ScalableValue {
 
     fn scale(self, target: ScaleTarget) -> (Self::Output, ScaleOutcome) {
         match self {
-            Self::Fixed { value } => (value, ScaleOutcome::Fixed),
-            Self::Linear { value } => match linear_scale(value.clone(), target.factor()) {
+            Self::Fixed(value) => (value, ScaleOutcome::Fixed),
+            Self::Linear(value) => match linear_scale(value.clone(), target.factor()) {
                 Ok(v) => (v, ScaleOutcome::Scaled),
                 Err(e) => (value, ScaleOutcome::Error(e)),
             },
-            Self::ByServings { ref values } => {
+            Self::ByServings(ref values) => {
                 if let Some(index) = target.index {
                     let value = match values.get(index) {
                         Some(v) => v,
@@ -258,9 +258,9 @@ impl Scale for ScalableValue {
 
     fn default_scale(self) -> Self::Output {
         match self {
-            Self::Fixed { value } => value,
-            Self::Linear { value } => value,
-            Self::ByServings { values } => values
+            Self::Fixed(value) => value,
+            Self::Linear(value) => value,
+            Self::ByServings(values) => values
                 .first()
                 .expect("scalable value servings list empty")
                 .clone(),
@@ -270,11 +270,9 @@ impl Scale for ScalableValue {
 
 fn linear_scale(value: Value, factor: f64) -> Result<Value, ScaleError> {
     match value {
-        Value::Number { value: n } => Ok(Value::Number { value: n * factor }),
-        Value::Range { value: r } => Ok(Value::Range {
-            value: r.start() * factor..=r.end() * factor,
-        }),
-        v @ Value::Text { value: _ } => Err(TextValueError(v).into()),
+        Value::Number(n) => Ok(Value::Number(n * factor)),
+        Value::Range(r) => Ok(Value::Range(r.start() * factor..=r.end() * factor)),
+        v @ Value::Text(_) => Err(TextValueError(v).into()),
     }
 }
 

--- a/tests/canonical.rs
+++ b/tests/canonical.rs
@@ -99,7 +99,7 @@ impl TestStepItem {
     fn from_cooklang_item(value: Item, recipe: &cooklang::ScalableRecipe) -> Self {
         match value {
             Item::Text { value } => Self::Text { value },
-            Item::ItemIngredient { index } => {
+            Item::Ingredient { index } => {
                 let i = &recipe.ingredients[index];
                 assert!(i.relation.is_definition());
                 assert!(i.relation.referenced_from().is_empty());
@@ -122,7 +122,7 @@ impl TestStepItem {
                     units,
                 }
             }
-            Item::ItemCookware { index } => {
+            Item::Cookware { index } => {
                 let i = &recipe.cookware[index];
                 assert!(i.relation.is_definition());
                 assert!(i.relation.referenced_from().is_empty());
@@ -139,7 +139,7 @@ impl TestStepItem {
                     quantity,
                 }
             }
-            Item::ItemTimer { index } => {
+            Item::Timer { index } => {
                 let i = &recipe.timers[index];
                 let quantity = i
                     .quantity
@@ -157,7 +157,7 @@ impl TestStepItem {
                     units,
                 }
             }
-            Item::InlineQuantity { .. } => panic!("Unexpected inline quantity"),
+            Item::InlineQuantity { index: _ } => panic!("Unexpected inline quantity"),
         }
     }
 }
@@ -165,13 +165,13 @@ impl TestStepItem {
 impl TestValue {
     fn from_cooklang_value(value: ScalableValue) -> Self {
         match value {
-            ScalableValue::Fixed { value } => match value {
-                Value::Number { value } => TestValue::Number(value),
-                Value::Range { .. } => panic!("unexpected range value"),
-                Value::Text { value } => TestValue::Text(value),
+            ScalableValue::Fixed(value) => match value {
+                Value::Number(value) => TestValue::Number(value),
+                Value::Range(_) => panic!("unexpected range value"),
+                Value::Text(value) => TestValue::Text(value),
             },
-            ScalableValue::Linear { .. } => panic!("unexpected linear value"),
-            ScalableValue::ByServings { .. } => panic!("unexpected value by servings"),
+            ScalableValue::Linear(_) => panic!("unexpected linear value"),
+            ScalableValue::ByServings(_) => panic!("unexpected value by servings"),
         }
     }
 }

--- a/tests/canonical.rs
+++ b/tests/canonical.rs
@@ -166,8 +166,8 @@ impl TestValue {
     fn from_cooklang_value(value: ScalableValue) -> Self {
         match value {
             ScalableValue::Fixed(value) => match value {
-                Value::Number(value) => TestValue::Number(value),
-                Value::Range(_) => panic!("unexpected range value"),
+                Value::Number(num) => TestValue::Number(num.value()),
+                Value::Range { .. } => panic!("unexpected range value"),
                 Value::Text(value) => TestValue::Text(value),
             },
             ScalableValue::Linear(_) => panic!("unexpected linear value"),

--- a/tests/fractions.rs
+++ b/tests/fractions.rs
@@ -1,6 +1,7 @@
 use cooklang::{convert::System, Converter, Quantity, Value};
 use test_case::test_case;
 
+#[test_case(2.0, "tsp" => "2 tsp")]
 #[test_case(3.0, "tsp" => "1 tbsp")]
 #[test_case(3.5, "tsp" => "3 1/2 tsp")]
 #[test_case(15.0, "tsp" => "5 tbsp")]

--- a/tests/fractions.rs
+++ b/tests/fractions.rs
@@ -1,0 +1,14 @@
+use cooklang::{convert::System, Converter, Quantity, Value};
+use test_case::test_case;
+
+#[test_case(3.0, "tsp" => "1 tbsp")]
+#[test_case(3.5, "tsp" => "3 1/2 tsp")]
+#[test_case(15.0, "tsp" => "5 tbsp")]
+#[test_case(16.0, "tsp" => "1/3 c")]
+fn imperial(value: f64, unit: &str) -> String {
+    let converter = Converter::default();
+    let mut q = Quantity::new(Value::from(value), Some(unit.to_string()));
+    let _ = q.convert(System::Imperial, &converter);
+    let _ = q.fit(&converter);
+    q.to_string()
+}

--- a/units.toml
+++ b/units.toml
@@ -17,16 +17,17 @@ centi = ["c"]
 milli = ["m"]
 
 [fractions]
-metric = { mixed_value = false }
-imperial = { mixed_value = true }
+metric = false
+imperial = true
 
 [fractions.specialization]
 tsp = { max_whole = 5, max_denominator = 2 }
-tbsp = { max_whole = 4, max_denominator = 2 }
+tbsp = { max_whole = 4, max_denominator = 3 }
+lb = { max_denominator = 8 }
 
 [[quantity]]
 quantity = "volume"
-best = { metric = ["ml", "l"], imperial = ["cup", "tsp", "tbsp", "fl oz"] }
+best = { metric = ["ml", "l"], imperial = ["cup", "tsp", "tbsp"] }
 [quantity.units]
 metric = [
     { names = ["liter", "liters", "litre", "litres"], symbols = ["l", "L"], ratio = 1, expand_si = true },

--- a/units.toml
+++ b/units.toml
@@ -26,19 +26,19 @@ tbsp = { max_whole = 4, max_denominator = 2 }
 
 [[quantity]]
 quantity = "volume"
-best = { metric = ["ml", "l"], imperial = ["cup", "tsp", "tbsp"] }
+best = { metric = ["ml", "l"], imperial = ["cup", "tsp", "tbsp", "fl oz"] }
 [quantity.units]
 metric = [
     { names = ["liter", "liters", "litre", "litres"], symbols = ["l", "L"], ratio = 1, expand_si = true },
 ]
 imperial = [
-    { names = ["cup", "cups"], symbols = ["c"], ratio = 0.2841306 },
-    { names = ["tablespoon", "tablespoons"], symbols = ["tbs", "tbs.", "tbsp", "tbsp."], ratio = 0.01775816 },
-    { names = ["teaspoon", "teaspoons"], symbols = ["tsp", "tsp."], ratio = 0.005919387 },
-    { names = ["fluid ounce", "fluid ounces"], symbols = ["fl oz", "fl. oz.", "fl. oz", "fl oz."], ratio = 0.02841306 },
-    { names = ["gallon", "gallons"], symbols = ["gal"], ratio = 4.54609 },
-    { names = ["pint", "pints"], symbols = ["pt"], ratio = 0.5682612 },
-    { names = ["quart", "quarts"], symbols = ["qt"], ratio = 1.136522 },
+    { names = ["teaspoon", "teaspoons"], symbols = ["tsp", "tsp."], ratio = 0.004_928_921 },
+    { names = ["tablespoon", "tablespoons"], symbols = ["tbsp", "tbsp.", "tbs", "tbs."], ratio = 0.014_786_764 },
+    { names = ["fluid ounce", "fluid ounces"], symbols = ["fl oz", "fl. oz.", "fl. oz", "fl oz."], ratio = 0.029_573_529 },
+    { names = ["cup", "cups"], symbols = ["c"], ratio = 0.236_588_236 },
+    { names = ["pint", "pints"], symbols = ["pt"], ratio = 0.473_176_473 },
+    { names = ["quart", "quarts"], symbols = ["qt"], ratio = 0.946_352_946 },
+    { names = ["gallon", "gallons"], symbols = ["gal"], ratio = 3.785_411_784 },
 ]
 
 [[quantity]]
@@ -49,7 +49,7 @@ metric = [
     { names = ["meter", "meters", "metre", "metres"], symbols = ["m"], ratio = 1, expand_si = true },
 ]
 imperial = [
-    { names = ["foot", "feet"], symbols = ["ft", "'"], ratio = 0.3084 },
+    { names = ["foot", "feet"], symbols = ["ft", "'"], ratio = 0.3048 },
     { names = ["inch", "inches"], symbols = ["in", "\""], ratio = 0.0254 },
 ]
 
@@ -61,8 +61,8 @@ metric = [
     { names = ["gram", "grams"], symbols = ["g"], ratio = 1, expand_si = true },
 ]
 imperial = [
-    { names = ["ounce", "ounces"], symbols = ["oz", "oz."], ratio = 28.34952 },
-    { names = ["pound", "pounds"], symbols = ["lb", "lb."], ratio = 453.5924 },
+    { names = ["ounce", "ounces"], symbols = ["oz", "oz."], ratio = 28.349_523_125 },
+    { names = ["pound", "pounds"], symbols = ["lb", "lb."], ratio = 453.592_37 },
 ]
 
 [[quantity]]

--- a/units.toml
+++ b/units.toml
@@ -16,6 +16,14 @@ deci = ["d"]
 centi = ["c"]
 milli = ["m"]
 
+[fractions]
+metric = { mixed_value = false }
+imperial = { mixed_value = true }
+
+[fractions.specialization]
+tsp = { max_whole = 5, max_denominator = 2 }
+tbsp = { max_whole = 4, max_denominator = 2 }
+
 [[quantity]]
 quantity = "volume"
 best = { metric = ["ml", "l"], imperial = ["cup", "tsp", "tbsp"] }


### PR DESCRIPTION
- Improves value parsing.
- Reverts enum to tuple variants where adequate because it's not needed for UniFFI anymore.
- `Quantity` can conversion/fitting now try to use a fraction.
- Change default imperial units to US customary.
- Expose more `Converter` behaviour in the public API.