### PR TITLE
Allowing more special chars for author/source 'name <url>'

### DIFF
--- a/extensions.md
+++ b/extensions.md
@@ -210,10 +210,18 @@ This extension enables extra parsing for some special metadata keys. These are:
 
 - `tags`. Comma separated list of tags.
 - `emoji`. Emoji or emoji shortcode, checked that it's an actual emoji.
-- `author`. Name, URL or both with the format `name <URL>`.
+- `author`. Name, URL or [both](#Name-with-URL) with the format `name <URL>`. 
 - `source`. Same as `author`.
 - `time`. Time string with unit support. Like `2 hour 30 min`. This overrides past `prep_time`/`cook_time`.
 - `prep_time`. Same format as `time`. Overrides past `time` but not `prep_time`.
 - `cook_time`. Same format as `time`. Overrides past `time` but not `cook_time`.
 
 _(`servings` is always parsed)_
+
+### Name with URL
+
+When using a name with an URL, the name can contain, besides alphanumerics, only space, `,`, `.`, `-`, `_`, `\`` and `'`.
+
+Example: `Mom's Cookbook <https://moms-cookbook.url>` -> name: `Mom's Cookbook` url: `https://moms-cookbook.url`
+
+

--- a/extensions.md
+++ b/extensions.md
@@ -220,7 +220,7 @@ _(`servings` is always parsed)_
 
 ### Name with URL
 
-When using a name with an URL, the name can contain, besides alphanumerics, only space, `,`, `.`, `-`, `_`, `\`` and `'`.
+When using a name with an URL, the name can contain, besides alphanumerics, only space, `,`, `.`, `-`, `_`, `#`, `` ` `` and `'`.
 
 Example: `Mom's Cookbook <https://moms-cookbook.url>` -> name: `Mom's Cookbook` url: `https://moms-cookbook.url`
 


### PR DESCRIPTION
Allowing more special chars in the name part with an url for author/source. Now the `name <url>` works also with space, `,`, `.`, `-`, `_`, `#`, `` ` `` and `'` .

For example, before this PR, it was not possible using names cointing this chars with URL like this:

`Iain M. Banks <https://some.url>` -> no name and url `Iain M. Banks <https://some.url>` 

Now it would be as expected:

`Iain M. Banks <https://some.url>` -> name `Iain M. Banks` and url `https://some.url`

I did not add `:` for the name part, because there is some unexpected behavior due to the dectection of URLs. I will raise an issue for it.

Btw, this is my first time doing something with rust. So maybe, I did this not the idiomatic rust way.

Have fun,
   someone.earth