### PR TITLE
Canonical metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased - ReleaseDate
 
+- Add support in `cooklang::metadata` for [canonical
+  metadata](https://cooklang.org/docs/spec/#canonical-metadata), making it
+  easier to query these keys and expected values.
+- Add warnings for missused canonical metadata keys.
+- Fix ingredients aliases from aisle configuration not being merged in
+  `IngredientList`. (#24 @kaylee-kiako)
+
+## 0.14.0 - 2024/12/11
+
+- Add YAML frontmatter for metadata. Deprecate old style metadata keys with the
+  `>>` syntax. This also comes with changes in the `cooklang::metadata` module.
+- Add deprecation and how to fix warnings when using old style metadata.
+- Remove `MULTILINE_STEPS`, `COMPONENT_NOTE`, `SECTIONS` and `TEXT_STEPS`
+  **extensions** as they are now part of the cooklang specification and are
+  always enabled.
+
 ## 0.13.3 - 2024/08/12
 - Replace `ariadne` dependency with `codesnake`. Because of this, errors may
   have some minor differences.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   metadata](https://cooklang.org/docs/spec/#canonical-metadata), making it
   easier to query these keys and expected values.
 - Add warnings for missused canonical metadata keys.
+- Improve custom checks for metadata keys. Now they can choose to skip the
+  included checks too.
 - Fix ingredients aliases from aisle configuration not being merged in
   `IngredientList`. (#24 @kaylee-kiako)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,6 @@ dependencies = [
  "codesnake",
  "criterion",
  "either",
- "emojis",
  "enum-map",
  "finl_unicode",
  "indoc",
@@ -438,15 +437,6 @@ name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
-
-[[package]]
-name = "emojis"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e1f1df1f181f2539bac8bf027d31ca5ffbf9e559e3f2d09413b9107b5c02f4"
-dependencies = [
- "phf",
-]
 
 [[package]]
 name = "enum-map"
@@ -955,24 +945,6 @@ dependencies = [
  "once_cell",
  "pest",
  "sha2",
-]
-
-[[package]]
-name = "phf"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
-dependencies = [
- "phf_shared",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
-dependencies = [
- "siphasher",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ thiserror = "1"
 url = { version = "2", features = ["serde"] }
 pest = { version = "2", optional = true }
 pest_derive = { version = "2", optional = true }
-emojis = "0.6"
 toml = { version = "0.8", optional = true }
 once_cell = "1"
 enum-map = { version = "2", features = ["serde"] }

--- a/playground/index.html
+++ b/playground/index.html
@@ -174,9 +174,10 @@
 
         <select id="parserSelect">
           <option value="render" selected>Render</option>
-          <option value="full" selected>Full parse</option>
+          <option value="full">Full parse</option>
           <option value="events">Events</option>
           <option value="ast">AST</option>
+          <option value="stdmeta">Standard metadata</option>
         </select>
         <div hidden id="servingscontainer">
           <label for="servings">Servings</label>
@@ -287,6 +288,12 @@
           }
           case "render": {
             const { value, error } = state.parse_render(input, servings.value.length === 0 ? null : servings.valueAsNumber);
+            output.innerHTML = value;
+            errors.innerHTML = error;
+            break;
+          }
+          case "stdmeta": {
+            const { value, error } = state.std_metadata(input);
             output.innerHTML = value;
             errors.innerHTML = error;
             break;

--- a/playground/index.html
+++ b/playground/index.html
@@ -219,7 +219,7 @@
   </main>
 
   <script type="module">
-    import init, { State,version } from "./pkg/cooklang_playground.js";
+    import init, { State, version } from "./pkg/cooklang_playground.js";
 
     async function run() {
       await init();
@@ -286,7 +286,7 @@
             break;
           }
           case "render": {
-            const { value, error } = state.parse_render(input, servings.value.length === 0 ? null : servings.valueAsNumber );
+            const { value, error } = state.parse_render(input, servings.value.length === 0 ? null : servings.valueAsNumber);
             output.innerHTML = value;
             errors.innerHTML = error;
             break;
@@ -329,21 +329,19 @@
       servings.addEventListener("change", () => parse());
 
       const extensionsContainer = document.getElementById("extensions-container");
+
       const extensions = [
-        "COMPONENT_MODIFIERS",
-        "COMPONENT_ALIAS",
-        "ADVANCED_UNITS",
-        "MODES",
-        "TEMPERATURE",
-        "RANGE_VALUES",
-        "TIMER_REQUIRES_TIME",
-        "INTERMEDIATE_PREPARATIONS",
-        "SPECIAL_METADATA",
-      ].forEach((e, i) => {
-        let bits = 1 << i;
-        if (i == 11) {
-          bits |= 1 << 1;
-        }
+        ["COMPONENT_MODIFIERS", 1 << 1],
+        ["COMPONENT_ALIAS", 1 << 3],
+        ["ADVANCED_UNITS", 1 << 5],
+        ["MODES", 1 << 6],
+        ["TEMPERATURE", 1 << 7],
+        ["RANGE_VALUES", 1 << 9],
+        ["TIMER_REQUIRES_TIME", 1 << 10],
+        ["INTERMEDIATE_PREPARATIONS", 1 << 11 | 1 << 1]
+      ];
+
+      extensions.forEach(([e, bits]) => {
         const elem = document.createElement("input");
         elem.setAttribute("type", "checkbox");
         elem.setAttribute("id", e);

--- a/src/analysis/event_consumer.rs
+++ b/src/analysis/event_consumer.rs
@@ -1454,6 +1454,8 @@ fn yaml_find_key_position(text: &str, key: &str) -> Option<usize> {
 
     let mut offset = 0;
     for line in text.split_inclusive('\n') {
+        let l_offset = offset;
+        offset += line.len();
         let line = line.trim_start();
 
         let Some((k, _)) = line.split_once(':') else {
@@ -1463,10 +1465,8 @@ fn yaml_find_key_position(text: &str, key: &str) -> Option<usize> {
             continue;
         };
         if k[start..].trim_ascii_end() == key {
-            return Some(offset + start);
+            return Some(l_offset + start);
         }
-
-        offset += line.len()
     }
     None
 }

--- a/src/analysis/event_consumer.rs
+++ b/src/analysis/event_consumer.rs
@@ -241,48 +241,9 @@ impl<'i> RecipeCollector<'i, '_> {
 
     fn process_frontmatter(&mut self, yaml_text: Text<'i>) {
         self.old_style_metadata = false;
-        match serde_yaml::from_str::<serde_yaml::Mapping>(&yaml_text.text()) {
-            Ok(yaml_map) => {
-                self.content.metadata.map = yaml_map;
-                let mut to_remove = Vec::new();
-                for (key, value) in self.content.metadata.map.iter() {
-                    let mut action = CheckOptions::default();
-                    // run custom validator if any
-                    if let Some(validator) = self.parse_options.metadata_validator.as_mut() {
-                        let res = validator(key, value, &mut action);
-                        if let Some(diag) = res.into_source_diag(|| "Invalid metadata entry") {
-                            // TODO can we get the position of the key value pair inside yaml_text?
-                            self.ctx.push(diag);
-                        }
-                        if !action.include {
-                            to_remove.push(key.clone());
-                            continue;
-                        }
-                    }
-
-                    if !action.run_std_checks {
-                        continue;
-                    }
-                    if let Some(sk) = key.as_str().and_then(|s| StdKey::from_str(s).ok()) {
-                        match check_std_entry(sk, value, self.converter) {
-                            Ok(Some(servings)) => self.content.data = servings,
-                            Ok(None) => {}
-                            Err(err) => {
-                                // TODO can we get the position of the key value pair inside yaml_text?
-                                let diag = warning!(format!(
-                                    "Unsupported value for key: '{}'",
-                                    key.as_str().unwrap()
-                                ))
-                                .set_source(err);
-                                self.ctx.warn(diag);
-                            }
-                        }
-                    }
-                }
-                for key in &to_remove {
-                    self.content.metadata.map.remove(key);
-                }
-            }
+        let yaml_str = yaml_text.text();
+        let mut yaml_map = match serde_yaml::from_str::<serde_yaml::Mapping>(&yaml_str) {
+            Ok(yaml_map) => yaml_map,
             Err(err) => {
                 // ! This message (can) contains line and column number, but line numbers
                 // ! are off by one thanks to the starting `---`
@@ -294,8 +255,93 @@ impl<'i> RecipeCollector<'i, '_> {
                     diag = diag.label(label!(loc));
                 }
                 self.ctx.error(diag);
+                return;
+            }
+        };
+
+        let mut to_remove = Vec::new();
+        for (key, value) in yaml_map.iter() {
+            let mut action = CheckOptions::default();
+            // run custom validator if any
+            if let Some(validator) = self.parse_options.metadata_validator.as_mut() {
+                let res = validator(key, value, &mut action);
+                if let Some(mut diag) = res.into_source_diag(|| "Invalid metadata entry") {
+                    if let Some(key_s) = key.as_str() {
+                        if let Some(pos) = yaml_find_key_position(&yaml_str, key_s) {
+                            diag.add_label(label!(Span::pos(yaml_text.span().start() + pos)));
+                        }
+                    }
+                    self.ctx.push(diag);
+                }
+                if !action.include {
+                    to_remove.push(key.clone());
+                    continue;
+                }
+            }
+
+            if !action.run_std_checks {
+                continue;
+            }
+            if let Some(sk) = key.as_str().and_then(|s| StdKey::from_str(s).ok()) {
+                match check_std_entry(sk, value, self.converter) {
+                    Ok(Some(servings)) => self.content.data = servings,
+                    Ok(None) => {}
+                    Err(err) => {
+                        let mut diag = warning!(format!(
+                            "Unsupported value for key: '{}'",
+                            key.as_str().unwrap()
+                        ))
+                        .set_source(err);
+                        if let Some(key_s) = key.as_str() {
+                            if let Some(pos) = yaml_find_key_position(&yaml_str, key_s) {
+                                diag.add_label(label!(Span::pos(yaml_text.span().start() + pos)));
+                            }
+                        }
+                        self.ctx.warn(diag);
+                    }
+                }
             }
         }
+        for key in &to_remove {
+            yaml_map.shift_remove(key);
+        }
+
+        if yaml_map.contains_key(StdKey::Time.as_ref()) {
+            // ? I guess I could group calls to `yaml_find_key_pos` into a single
+            // iteration of yaml_str but doesn't really matter
+
+            let loc = |key: StdKey| -> Option<usize> {
+                yaml_map
+                    .contains_key(key.as_ref())
+                    .then(|| yaml_find_key_position(&yaml_str, key.as_ref()))
+                    .flatten()
+            };
+
+            let prep = loc(StdKey::PrepTime);
+            let cook = loc(StdKey::CookTime);
+
+            const OVERRIDEN: &str = "this entry is overriden";
+            const OVERRIDES: &str = "this entry has preference";
+
+            if prep.is_some() || cook.is_some() {
+                let mut w = warning!("Time overriden");
+                if let Some(p) = prep {
+                    w.add_label(label!(Span::pos(yaml_text.span().start() + p), OVERRIDEN));
+                }
+                if let Some(p) = cook {
+                    w.add_label(label!(Span::pos(yaml_text.span().start() + p), OVERRIDEN));
+                }
+                if let Some(p) = yaml_find_key_position(&yaml_str, StdKey::Time.as_ref()) {
+                    w.add_label(label!(Span::pos(yaml_text.span().start() + p), OVERRIDES));
+                }
+                w.add_hint(
+                    "Top level 'prep time' and/or 'cook time' are not compatible with 'time'",
+                );
+                self.ctx.warn(w);
+            }
+        }
+
+        self.content.metadata.map = yaml_map;
     }
 
     fn metadata(&mut self, key: Text<'i>, value: Text<'i>) {
@@ -396,7 +442,7 @@ impl<'i> RecipeCollector<'i, '_> {
                 Err(err) => {
                     self.ctx.warn(
                         warning!(
-                            format!("Unsupported value for std key: '{}'", key.text_trimmed()),
+                            format!("Unsupported value for key: '{}'", key.text_trimmed()),
                             label!(value.span(), "this value"),
                         )
                         .label(label!(key.span(), "this key does not support"))
@@ -1400,4 +1446,27 @@ fn text_val_in_ref_warn(
         w.add_hint(IMPLICIT_REF_WARN);
     }
     w
+}
+
+fn yaml_find_key_position(text: &str, key: &str) -> Option<usize> {
+    // This is a bit of a hack, but it will work almost always and if it doesn't
+    // it only tells the user a bad position
+
+    let mut offset = 0;
+    for line in text.split_inclusive('\n') {
+        let line = line.trim_start();
+
+        let Some((k, _)) = line.split_once(':') else {
+            continue;
+        };
+        let Some(start) = k.find(|c: char| !c.is_ascii_whitespace()) else {
+            continue;
+        };
+        if k[start..].trim_ascii_end() == key {
+            return Some(offset + start);
+        }
+
+        offset += line.len()
+    }
+    None
 }

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -34,10 +34,9 @@ pub struct ParseOptions<'a> {
     /// Check metadata entries for validity
     ///
     /// Some checks are performed by default, but you can add your own here.
-    /// The function receives the key and the value.
-    ///
-    /// The boolean returned indicates if the value should be included in the
-    /// recipe.
+    /// The function receives the key, value and an [`CheckOptions`] where you
+    /// can customize what happens to the key, including not running the default
+    /// checks.
     pub metadata_validator: Option<MetadataValidator<'a>>,
 }
 
@@ -72,6 +71,45 @@ impl CheckResult {
     }
 }
 
+/// Customize how a metadata entry should be treated
+///
+/// By default the entry is included and the [`StdKey`](crate::metadata::StdKey)
+/// checks run.
+pub struct CheckOptions {
+    include: bool,
+    run_std_checks: bool,
+}
+
+impl Default for CheckOptions {
+    fn default() -> Self {
+        Self {
+            include: true,
+            run_std_checks: true,
+        }
+    }
+}
+
+impl CheckOptions {
+    /// To include or not the metadata entry in the recipe
+    ///
+    /// If this is `false`, the entry will not be in the recipe. This will avoid
+    /// keeping invalid values.
+    pub fn include(&mut self, do_include: bool) {
+        self.include = do_include;
+    }
+
+    /// To run or not the checks for [`StdKey`](crate::metadata::StdKey)
+    ///
+    /// Disable these checks if you want to change the semantics or structure of a
+    /// [`StdKey`](crate::metadata::StdKey) and don't want the parser to issue
+    /// warnings about it.
+    ///
+    /// If the key is **not** an [`StdKey`](crate::metadata::StdKey) this has no effect.
+    pub fn run_std_checks(&mut self, do_check: bool) {
+        self.run_std_checks = do_check;
+    }
+}
+
 pub type RecipeRefCheck<'a> = Box<dyn FnMut(&str) -> CheckResult + 'a>;
 pub type MetadataValidator<'a> =
-    Box<dyn FnMut(&serde_yaml::Value, &serde_yaml::Value) -> (CheckResult, bool) + 'a>;
+    Box<dyn FnMut(&serde_yaml::Value, &serde_yaml::Value, &mut CheckOptions) -> CheckResult + 'a>;

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,10 +6,10 @@ use crate::Span;
 
 /// Handy label creation for [`SourceDiag`]
 macro_rules! label {
-    ($span:expr) => {
+    ($span:expr $(,)?) => {
         ($span.to_owned().into(), None)
     };
-    ($span:expr, $message:expr) => {
+    ($span:expr, $message:expr $(,)?) => {
         ($span.to_owned().into(), Some($message.into()))
     };
     ($span:expr, $fmt:literal, $($arg:expr),+) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,8 +129,6 @@ bitflags! {
         const TIMER_REQUIRES_TIME      = 1 << 10;
         /// This extensions also enables [`Self::COMPONENT_MODIFIERS`].
         const INTERMEDIATE_PREPARATIONS = 1 << 11 | Self::COMPONENT_MODIFIERS.bits();
-        /// Enables special metadata key parsing
-        const SPECIAL_METADATA = 1 << 12;
 
         /// Enables a subset of extensions to maximize compatibility with other
         /// cooklang parsers.
@@ -145,8 +143,7 @@ bitflags! {
                         | Self::MODES.bits()
                         | Self::TEMPERATURE.bits()
                         | Self::RANGE_VALUES.bits()
-                        | Self::INTERMEDIATE_PREPARATIONS.bits()
-                        | Self::SPECIAL_METADATA.bits();
+                        | Self::INTERMEDIATE_PREPARATIONS.bits();
     }
 }
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -86,8 +86,8 @@ impl FromStr for StdKey {
             "course" | "category" => Self::Course,
             "locale" => Self::Locale,
             "time" | "duration" | "time required" => Self::Time,
-            "prep time" => Self::PrepTime,
-            "cook time" => Self::CookTime,
+            "prep time" | "prep_time" => Self::PrepTime,
+            "cook time" | "cook_time" => Self::CookTime,
             "difficulty" => Self::Difficulty,
             "cuisine" => Self::Cuisine,
             "diet" => Self::Diet,
@@ -179,7 +179,7 @@ impl Metadata {
     /// Time it takes to prepare/cook the recipe
     ///
     /// The `time` key [`as_time`](CooklangValueExt::as_time). Or, if missing,
-    /// the combination of the `prep_time` and `cook_time` keys
+    /// the combination of the `prep time` and `cook time` keys
     /// [`as_minutes`](CooklangValueExt::as_minutes).
     pub fn time(&self, converter: &Converter) -> Option<RecipeTime> {
         if let Some(time_val) = self.get(StdKey::Time.as_ref()) {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -48,7 +48,7 @@ pub struct Metadata {
 /// recipe between different cooklang applications. You can read more about it
 /// in [the spec](https://cooklang.org/docs/spec/#canonical-metadata).
 ///
-/// To use them, use [`Metadata::get_std`].
+/// To use them, use [`Metadata::get`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum StdKey {
@@ -171,7 +171,7 @@ impl Metadata {
     ///
     /// This *who* wrote the recipe.
     ///
-    /// The `author` key [`as_name_and_url`](CooklangValueExt::as_value_and_url).
+    /// The `author` key [`as_name_and_url`](CooklangValueExt::as_name_and_url).
     pub fn author(&self) -> Option<NameAndUrl> {
         self.get(StdKey::Author)
             .and_then(CooklangValueExt::as_name_and_url)
@@ -181,7 +181,7 @@ impl Metadata {
     ///
     /// This *where* the recipe was obtained from.
     ///
-    /// The `source` key [`as_name_and_url`](CooklangValueExt::as_value_and_url).
+    /// The `source` key [`as_name_and_url`](CooklangValueExt::as_name_and_url).
     pub fn source(&self) -> Option<NameAndUrl> {
         self.get(StdKey::Source)
             .and_then(CooklangValueExt::as_name_and_url)
@@ -338,8 +338,9 @@ pub trait CooklangValueExt: private::Sealed {
 
     /// Get a [`RecipeTime`]
     ///
-    /// This can be a single number or string like in [`as_minutes`] or a mapping
-    /// of `prep_time` and `cook_time` where each of them is a number or string.
+    /// This can be a single number or string like in
+    /// [`as_minutes`](CooklangValueExt::as_minutes) or a mapping of `prep_time`
+    /// and `cook_time` where each of them is a number or string.
     fn as_time(&self, converter: &Converter) -> Option<RecipeTime>;
 
     /// Like [`serde_yaml::Value::as_u64`] but ensuring the value fits in a u32

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -35,46 +35,98 @@ pub struct Metadata {
     pub map: serde_yaml::Mapping,
 }
 
-#[derive(
-    Debug,
-    Clone,
-    Copy,
-    strum::Display,
-    strum::EnumString,
-    strum::AsRefStr,
-    PartialEq,
-    Eq,
-    Hash,
-    Serialize,
-    Deserialize,
-)]
+/// Standard keys from the cooklang spec
+///
+/// These keys are recommended to be used to maximise the compatibility of a
+/// recipe between different cooklang applications. You can read more about it
+/// in [the spec](https://cooklang.org/docs/spec/#canonical-metadata).
+///
+/// To use them, use [`Metadata::get_std`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-#[strum(serialize_all = "snake_case")]
-pub(crate) enum StdKey {
+pub enum StdKey {
+    Title,
     Description,
-    #[strum(serialize = "tag", to_string = "tags")]
     Tags,
-    Emoji,
     Author,
     Source,
-    Time,
-    #[strum(serialize = "prep_time", to_string = "prep time")]
-    PrepTime,
-    #[strum(serialize = "cook_time", to_string = "cook time")]
-    CookTime,
     Servings,
+    Course,
+    Locale,
+    Time,
+    PrepTime,
+    CookTime,
+    Difficulty,
+    Cuisine,
+    Diet,
+    Images,
+}
+
+impl std::fmt::Display for StdKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_ref())
+    }
+}
+
+#[derive(thiserror::Error, Debug, Clone)]
+#[error("Faile to parse '{0}' as a standard key")]
+pub struct StdKeyParseError(String);
+
+impl FromStr for StdKey {
+    type Err = StdKeyParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let k = match s {
+            "title" => Self::Title,
+            "description" | "introduction" => Self::Description,
+            "tags" | "tag" => Self::Tags,
+            "author" => Self::Author,
+            "source" => Self::Source,
+            "servings" | "serves" | "yield" => Self::Servings,
+            "course" | "category" => Self::Course,
+            "locale" => Self::Locale,
+            "time" | "duration" | "time required" => Self::Time,
+            "prep time" => Self::PrepTime,
+            "cook time" => Self::CookTime,
+            "difficulty" => Self::Difficulty,
+            "cuisine" => Self::Cuisine,
+            "diet" => Self::Diet,
+            "image" | "images" | "picture" | "pictures" => Self::Images,
+            _ => return Err(StdKeyParseError(s.to_string())),
+        };
+        Ok(k)
+    }
+}
+
+impl AsRef<str> for StdKey {
+    fn as_ref(&self) -> &str {
+        match self {
+            StdKey::Title => "title",
+            StdKey::Description => "description",
+            StdKey::Tags => "tags",
+            StdKey::Author => "author",
+            StdKey::Source => "source",
+            StdKey::Servings => "servings",
+            StdKey::Course => "course",
+            StdKey::Locale => "locale",
+            StdKey::Time => "time",
+            StdKey::PrepTime => "prep time",
+            StdKey::CookTime => "cook time",
+            StdKey::Difficulty => "difficulty",
+            StdKey::Cuisine => "cuisine",
+            StdKey::Diet => "diet",
+            StdKey::Images => "image",
+        }
+    }
 }
 
 impl Metadata {
-    pub fn get(&self, index: impl serde_yaml::mapping::Index) -> Option<&serde_yaml::Value> {
-        self.map.get(index)
+    pub fn get(&self, index: impl MetaIndex) -> Option<&serde_yaml::Value> {
+        index.index_into(&self.map)
     }
 
-    pub fn get_mut(
-        &mut self,
-        index: impl serde_yaml::mapping::Index,
-    ) -> Option<&mut serde_yaml::Value> {
-        self.map.get_mut(index)
+    pub fn get_mut(&mut self, index: impl MetaIndex) -> Option<&mut serde_yaml::Value> {
+        index.index_into_mut(&mut self.map)
     }
 
     /// Iterates over all entries except the standard keys
@@ -93,21 +145,15 @@ impl Metadata {
     /// Just the `description` key as a string.
     pub fn description(&self) -> Option<&str> {
         self.get(StdKey::Description.as_ref())
-            .and_then(|v| v.as_str())
-    }
-
-    /// Emoji for the recipe
-    ///
-    /// The `emoji` key [`as_emoji`](CooklangValueExt::as_emoji)
-    pub fn emoji(&self) -> Option<&str> {
-        self.get(StdKey::Emoji.as_ref()).and_then(|v| v.as_emoji())
+            .and_then(serde_yaml::Value::as_str)
     }
 
     /// List of tags
     ///
     /// The `tags` key [`as_tags`](CooklangValueExt::as_tags)
     pub fn tags(&self) -> Option<Vec<&str>> {
-        self.get(StdKey::Tags.as_ref()).and_then(|v| v.as_tags())
+        self.get(StdKey::Tags.as_ref())
+            .and_then(CooklangValueExt::as_tags)
     }
 
     /// Author
@@ -117,7 +163,7 @@ impl Metadata {
     /// The `author` key [`as_name_and_url`](CooklangValueExt::as_value_and_url).
     pub fn author(&self) -> Option<NameAndUrl> {
         self.get(StdKey::Author.as_ref())
-            .and_then(|v| v.as_name_and_url())
+            .and_then(CooklangValueExt::as_name_and_url)
     }
 
     /// Source
@@ -127,7 +173,7 @@ impl Metadata {
     /// The `source` key [`as_name_and_url`](CooklangValueExt::as_value_and_url).
     pub fn source(&self) -> Option<NameAndUrl> {
         self.get(StdKey::Source.as_ref())
-            .and_then(|v| v.as_name_and_url())
+            .and_then(CooklangValueExt::as_name_and_url)
     }
 
     /// Time it takes to prepare/cook the recipe
@@ -157,27 +203,103 @@ impl Metadata {
     }
 
     /// Servings the recipe is made for
+    ///
+    /// This returns a list of servings to support scaling. See
+    /// [`CooklangValueExt::as_servings`] for the expected format.
     pub fn servings(&self) -> Option<Vec<u32>> {
         self.get(StdKey::Servings.as_ref())
-            .and_then(|v| v.as_servings())
+            .and_then(CooklangValueExt::as_servings)
+    }
+
+    /// Recipe locale
+    /// See [`CooklangValueExt`] for the expected format.
+    pub fn locale(&self) -> Option<(&str, Option<&str>)> {
+        self.get(StdKey::Locale.as_ref())
+            .and_then(CooklangValueExt::as_locale)
+    }
+}
+
+pub trait MetaIndex: private::Sealed {
+    fn index_into<'a>(&self, m: &'a serde_yaml::Mapping) -> Option<&'a serde_yaml::Value>;
+    fn index_into_mut<'a>(
+        &self,
+        m: &'a mut serde_yaml::Mapping,
+    ) -> Option<&'a mut serde_yaml::Value>;
+}
+
+mod private {
+    pub trait Sealed {}
+    impl Sealed for super::StdKey {}
+    impl<T> Sealed for T where T: serde_yaml::mapping::Index {}
+}
+
+impl MetaIndex for StdKey {
+    #[inline]
+    fn index_into<'a>(&self, m: &'a serde_yaml::Mapping) -> Option<&'a serde_yaml::Value> {
+        m.get(self.as_ref())
+    }
+
+    #[inline]
+    fn index_into_mut<'a>(
+        &self,
+        m: &'a mut serde_yaml::Mapping,
+    ) -> Option<&'a mut serde_yaml::Value> {
+        m.get_mut(self.as_ref())
+    }
+}
+
+impl<T> MetaIndex for T
+where
+    T: serde_yaml::mapping::Index,
+{
+    #[inline]
+    fn index_into<'a>(&self, m: &'a serde_yaml::Mapping) -> Option<&'a serde_yaml::Value> {
+        m.get(self)
+    }
+
+    #[inline]
+    fn index_into_mut<'a>(
+        &self,
+        m: &'a mut serde_yaml::Mapping,
+    ) -> Option<&'a mut serde_yaml::Value> {
+        m.get_mut(self)
     }
 }
 
 pub trait CooklangValueExt: private::Sealed {
-    /// Returns `Some` only if the value is a string and it's an emoji.
-    ///
-    /// It can be a literal emoji (`🦀`) or a shortcode like `:crab:`
-    fn as_emoji(&self) -> Option<&str>;
-
-    /// Comma (',') separated string or YAML sequence of string
+    /// Comma (',') separated string or YAML sequence of strings
     ///
     /// Duplicates and empty entries removed.
     fn as_tags(&self) -> Option<Vec<&str>>;
 
     /// Pipe ('|') separated string or YAML sequence of numbers
     ///
-    /// Duplicates not allowed.
+    /// This extracts only the number at the beginning, but the entry can have
+    /// extra text, like the unit. For example:
+    /// ```yaml
+    /// servings: 5 cups worth
+    /// ```
+    /// will return `vec![5]`.
+    ///
+    /// These values will be used for scaling the recipe. If you want to display
+    /// the full text alongside the values, you can do something like:
+    ///
+    /// ```ignore     
+    /// let nums = metadata.get("servings")?.as_servings()?;
+    /// let texts  = metadata.get("servings")?.as_string_list("|")?;
+    ///
+    /// for num, text in nums.iter().zip(texts.iter()) {
+    ///     println!("{val} - '{text}'")
+    /// }
+    /// ```
+    ///
+    /// Duplicates not allowed, will return `None`.
     fn as_servings(&self) -> Option<Vec<u32>>;
+
+    /// String separated by `sep` or YAML sequence of strings and/or numbers
+    ///
+    /// This only checks types and convert numbers to strings if neccesary.
+    fn as_string_list<'a>(&'a self, sep: &str) -> Option<Vec<std::borrow::Cow<'a, str>>>;
 
     /// Get a [`NameAndUrl`]
     ///
@@ -204,24 +326,45 @@ pub trait CooklangValueExt: private::Sealed {
 
     /// Like [`serde_yaml::Value::as_u64`] but ensuring the value fits in a u32
     fn as_u32(&self) -> Option<u32>;
-}
 
-mod private {
-    pub trait Sealed {}
-    impl Sealed for serde_yaml::Value {}
+    /// Locale string
+    ///
+    /// ISO 639 language code, then optionally an underscore and the ISO 3166
+    /// alpha2 "country code" for dialect variants.
+    ///
+    /// **This only check that the value is a string and has the correct
+    /// structure**. Therefore it can return non existent/assigned locales.
+    /// Capitalisation is not checked, so, for example, `en_gb` works even
+    /// though it _should_ be `en_GB`.
+    fn as_locale(&self) -> Option<(&str, Option<&str>)>;
 }
 
 impl CooklangValueExt for serde_yaml::Value {
-    fn as_emoji(&self) -> Option<&str> {
-        value_as_emoji(self).ok()
-    }
-
     fn as_tags(&self) -> Option<Vec<&str>> {
         value_as_tags(self).ok()
     }
 
     fn as_servings(&self) -> Option<Vec<u32>> {
         value_as_servings(self).ok()
+    }
+
+    fn as_string_list<'a>(&'a self, sep: &str) -> Option<Vec<std::borrow::Cow<'a, str>>> {
+        if let Some(s) = self.as_str() {
+            let v = s.split(sep).map(|e| e.into()).collect();
+            Some(v)
+        } else if let Some(seq) = self.as_sequence() {
+            let mut v = Vec::<std::borrow::Cow<'a, str>>::with_capacity(seq.len());
+            for e in seq {
+                if let Some(s) = self.as_str() {
+                    v.push(s.into());
+                } else if let serde_yaml::Value::Number(n) = e {
+                    v.push(n.to_string().into());
+                }
+            }
+            Some(v)
+        } else {
+            None
+        }
     }
 
     fn as_name_and_url(&self) -> Option<NameAndUrl> {
@@ -245,24 +388,13 @@ impl CooklangValueExt for serde_yaml::Value {
         value_as_time(self, converter).ok()
     }
 
-    #[inline]
     fn as_u32(&self) -> Option<u32> {
         self.as_u64()?.try_into().ok()
     }
-}
 
-fn value_as_emoji(val: &serde_yaml::Value) -> Result<&str, MetadataError> {
-    let s = val.as_str().ok_or(MetadataError::UnexpectedType)?;
-    let emoji = if s.starts_with(':') && s.ends_with(':') {
-        emojis::get_by_shortcode(&s[1..s.len() - 1])
-    } else {
-        emojis::get(s)
-    };
-    emoji
-        .map(|e| e.as_str())
-        .ok_or_else(|| MetadataError::NotEmoji {
-            value: s.to_string(),
-        })
+    fn as_locale(&self) -> Option<(&str, Option<&str>)> {
+        value_as_locale(self).ok()
+    }
 }
 
 fn value_as_tags(val: &serde_yaml::Value) -> Result<Vec<&str>, MetadataError> {
@@ -272,9 +404,12 @@ fn value_as_tags(val: &serde_yaml::Value) -> Result<Vec<&str>, MetadataError> {
         seq.iter()
             .map(|val| val.as_str())
             .collect::<Option<Vec<&str>>>()
-            .ok_or(MetadataError::UnexpectedType)?
+            .ok_or(MetadataError::BadSequenceType {
+                expected: MetaType::String,
+                got: seq.first().map(MetaType::from).unwrap_or(MetaType::Unknown),
+            })?
     } else {
-        return Err(MetadataError::UnexpectedType);
+        return Err(MetadataError::expect_type(MetaType::Sequence, val));
     };
     let mut tags = Vec::with_capacity(entries.len());
     for tag in entries {
@@ -287,20 +422,38 @@ fn value_as_tags(val: &serde_yaml::Value) -> Result<Vec<&str>, MetadataError> {
 }
 
 fn value_as_servings(val: &serde_yaml::Value) -> Result<Vec<u32>, MetadataError> {
-    let servings: Vec<u32> = if let Some(s) = val.as_str() {
+    fn extract_value(s: &str) -> Result<u32, std::num::ParseIntError> {
+        let idx = s
+            .find(|c: char| !c.is_ascii_alphanumeric())
+            .unwrap_or(s.len());
+        let n_str = &s[..idx];
+        n_str.parse()
+    }
+
+    let servings: Vec<u32> = if let Some(n) = val.as_u32() {
+        vec![n]
+    } else if let Some(s) = val.as_str() {
         s.split('|')
             .map(str::trim)
-            .map(str::parse)
+            .map(extract_value)
             .collect::<Result<Vec<_>, _>>()?
     } else if let Some(seq) = val.as_sequence() {
         let mut v = Vec::with_capacity(seq.len());
         for e in seq {
-            let n = e.as_u32().ok_or(MetadataError::UnexpectedType)?;
-            v.push(n);
+            if let Some(n) = e.as_u32() {
+                v.push(n);
+            } else if let Some(s) = e.as_str() {
+                v.push(extract_value(s)?);
+            } else {
+                return Err(MetadataError::BadSequenceType {
+                    expected: MetaType::Number,
+                    got: MetaType::from(e),
+                });
+            }
         }
         v
     } else {
-        return Err(MetadataError::UnexpectedType);
+        return Err(MetadataError::expect_type(MetaType::Sequence, val));
     };
 
     let l = servings.len();
@@ -323,7 +476,7 @@ fn value_as_minutes(val: &serde_yaml::Value, converter: &Converter) -> Result<u3
     } else if let Some(n) = val.as_u32() {
         Ok(n)
     } else {
-        Err(MetadataError::UnexpectedType)
+        Err(MetadataError::expect_type(MetaType::String, val))
     }
 }
 
@@ -334,14 +487,16 @@ fn value_as_time(
     let total_res = value_as_minutes(val, converter);
     match total_res {
         Ok(total) => Ok(RecipeTime::Total(total)),
-        Err(MetadataError::UnexpectedType) => {
-            let map = val.as_mapping().ok_or(MetadataError::UnexpectedType)?;
+        Err(MetadataError::BadType { .. }) => {
+            let map = val
+                .as_mapping()
+                .ok_or(MetadataError::expect_type(MetaType::Mapping, val))?;
             let prep_time = map
-                .get(StdKey::PrepTime.as_ref())
+                .get("prep")
                 .map(|v| value_as_minutes(v, converter))
                 .transpose()?;
             let cook_time = map
-                .get(StdKey::CookTime.as_ref())
+                .get("cook")
                 .map(|v| value_as_minutes(v, converter))
                 .transpose()?;
             Ok(RecipeTime::Composed {
@@ -353,19 +508,62 @@ fn value_as_time(
     }
 }
 
+fn value_as_locale(val: &serde_yaml::Value) -> Result<(&str, Option<&str>), MetadataError> {
+    let s = val
+        .as_str()
+        .ok_or(MetadataError::expect_type(MetaType::String, val))?;
+
+    fn validate(s: &str) -> bool {
+        s.len() == 2 && s.chars().all(|c| c.is_ascii_alphabetic())
+    }
+
+    if let Some((lang, dial)) = s.split_once("_") {
+        if validate(lang) && validate(dial) {
+            return Ok((lang, Some(dial)));
+        }
+    } else if validate(s) {
+        return Ok((s, None));
+    }
+    Err(MetadataError::InvalidLocale(s.to_string()))
+}
+
 pub(crate) fn check_std_entry(
     key: StdKey,
     value: &serde_yaml::Value,
     converter: &Converter,
 ) -> Result<Option<crate::scale::Servings>, MetadataError> {
     match key {
-        StdKey::Tags => value_as_tags(value).map(|_| None),
-        StdKey::Emoji => value_as_emoji(value).map(|_| None),
-        StdKey::Time => value_as_time(value, converter).map(|_| None),
-        StdKey::PrepTime | StdKey::CookTime => value_as_minutes(value, converter).map(|_| None),
-        StdKey::Servings => value_as_servings(value).map(|s| Some(crate::scale::Servings(Some(s)))),
-        _ => Ok(None),
+        StdKey::Servings => {
+            return value_as_servings(value).map(|s| Some(crate::scale::Servings(Some(s))))
+        }
+        StdKey::Tags => {
+            value_as_tags(value)?;
+        }
+        StdKey::Time => {
+            value_as_time(value, converter)?;
+        }
+        StdKey::PrepTime | StdKey::CookTime => {
+            value_as_minutes(value, converter)?;
+        }
+        StdKey::Title | StdKey::Description => {
+            value
+                .as_str()
+                .ok_or(MetadataError::expect_type(MetaType::String, value))?;
+        }
+        StdKey::Locale => {
+            value_as_locale(value)?;
+        }
+        // these have no validation
+        StdKey::Author => {}
+        StdKey::Source => {}
+        StdKey::Course => {}
+        StdKey::Difficulty => {}
+        StdKey::Cuisine => {}
+        StdKey::Diet => {}
+        StdKey::Images => {}
     }
+
+    Ok(None)
 }
 
 /// Combination of name and URL.
@@ -376,123 +574,6 @@ pub(crate) fn check_std_entry(
 pub struct NameAndUrl {
     name: Option<String>,
     url: Option<Url>,
-}
-
-/// Time that takes to prep/cook a recipe
-///
-/// All values are in minutes.
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
-#[serde(untagged, deny_unknown_fields)]
-pub enum RecipeTime {
-    /// Total time
-    Total(u32),
-    /// Combination of preparation and cook time
-    ///
-    /// At least one is [`Some`]
-    Composed {
-        #[serde(alias = "prep")]
-        prep_time: Option<u32>,
-        #[serde(alias = "cook")]
-        cook_time: Option<u32>,
-    },
-}
-
-/// Returns minutes
-fn parse_time(s: &str, converter: &Converter) -> Result<u32, ParseTimeError> {
-    if s.is_empty() {
-        return Err(ParseTimeError::Empty);
-    }
-    let r = parse_time_with_units(s, converter);
-    // if any error, try to fall back to a full float parse
-    if r.is_err() {
-        let minutes = s.parse::<f64>().map(|m| m.round() as u32);
-        if let Ok(minutes) = minutes {
-            return Ok(minutes);
-        }
-    }
-    // otherwise return the result whatever it was
-    r
-}
-
-#[derive(Debug, thiserror::Error)]
-pub(crate) enum ParseTimeError {
-    #[error("A value is missing a unit")]
-    MissingUnit,
-    #[error("Could not find minutes in the configuration")]
-    MinutesNotFound,
-    #[error(transparent)]
-    ConvertError(#[from] ConvertError),
-    #[error(transparent)]
-    ParseFloatError(#[from] ParseFloatError),
-    #[error("An empty value is not valid")]
-    Empty,
-}
-
-fn dynamic_time_units(
-    value: f64,
-    unit: &str,
-    converter: &Converter,
-) -> Result<f64, ParseTimeError> {
-    // TODO maybe make this configurable? It will work for 99% of users...
-    let minutes = converter
-        .find_unit("min")
-        .or_else(|| converter.find_unit("minute"))
-        .or_else(|| converter.find_unit("minutes"))
-        .or_else(|| converter.find_unit("m"))
-        .ok_or(ParseTimeError::MinutesNotFound)?;
-    if minutes.physical_quantity != PhysicalQuantity::Time {
-        return Err(ParseTimeError::MinutesNotFound);
-    }
-    let (value, _) = converter.convert(
-        ConvertValue::Number(value),
-        ConvertUnit::Key(unit),
-        ConvertTo::from(&minutes),
-    )?;
-    match value {
-        ConvertValue::Number(n) => Ok(n),
-        _ => unreachable!(),
-    }
-}
-
-fn hard_coded_time_units(value: f64, unit: &str) -> Result<f64, ParseTimeError> {
-    let minutes = match unit {
-        "s" | "sec" | "secs" | "second" | "seconds" => value / 60.0,
-        "m" | "min" | "minute" | "minutes" => value,
-        "h" | "hour" | "hours" => value * 60.0,
-        "d" | "day" | "days" => value * 24.0 * 60.0,
-        _ => return Err(ConvertError::UnknownUnit(UnknownUnit(unit.to_string())).into()),
-    };
-    Ok(minutes)
-}
-
-fn parse_time_with_units(s: &str, converter: &Converter) -> Result<u32, ParseTimeError> {
-    let to_minutes = |value, unit| {
-        if converter.unit_count() == 0 {
-            hard_coded_time_units(value, unit)
-        } else {
-            dynamic_time_units(value, unit, converter)
-        }
-    };
-
-    let mut total = 0.0;
-    let mut parts = s.split_whitespace();
-    while let Some(part) = parts.next() {
-        let first_non_digit_pos = part
-            .char_indices()
-            .find_map(|(pos, c)| (!c.is_numeric() && c != '.').then_some(pos));
-        let (number, unit) = if let Some(mid) = first_non_digit_pos {
-            // if the part contains a non numeric char, split it in two and it will
-            // be the unit
-            part.split_at(mid)
-        } else {
-            // otherwise, take the next part as the unit
-            let next = parts.next().ok_or(ParseTimeError::MissingUnit)?;
-            (part, next)
-        };
-        let number = number.parse::<f64>()?;
-        total += to_minutes(number, unit)?;
-    }
-    Ok(total.round() as u32)
 }
 
 impl NameAndUrl {
@@ -546,6 +627,139 @@ impl NameAndUrl {
     }
 }
 
+/// Time that takes to prep/cook a recipe
+///
+/// All values are in minutes.
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
+#[serde(untagged, deny_unknown_fields)]
+pub enum RecipeTime {
+    /// Total time
+    Total(u32),
+    /// Combination of preparation and cook time
+    ///
+    /// At least one is [`Some`]
+    Composed {
+        #[serde(alias = "prep")]
+        prep_time: Option<u32>,
+        #[serde(alias = "cook")]
+        cook_time: Option<u32>,
+    },
+}
+
+/// Returns minutes
+fn parse_time(s: &str, converter: &Converter) -> Result<u32, ParseTimeError> {
+    if s.is_empty() {
+        return Err(ParseTimeError::Empty);
+    }
+
+    if let Some(minutes) = parse_common_time_format(s) {
+        return Ok(minutes);
+    }
+
+    let r = parse_time_with_units(s, converter);
+    // if any error, try to fall back to a full float parse
+    if r.is_err() {
+        let minutes = s.parse::<f64>().map(|m| m.round() as u32);
+        if let Ok(minutes) = minutes {
+            return Ok(minutes);
+        }
+    }
+    // otherwise return the result whatever it was
+    r
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum ParseTimeError {
+    #[error("A value is missing a unit")]
+    MissingUnit,
+    #[error("Could not find minutes in the configuration")]
+    MinutesNotFound,
+    #[error(transparent)]
+    ConvertError(#[from] ConvertError),
+    #[error(transparent)]
+    ParseFloatError(#[from] ParseFloatError),
+    #[error("An empty value is not valid")]
+    Empty,
+}
+
+fn parse_common_time_format(s: &str) -> Option<u32> {
+    let (hours_str, s) = s.split_once("h")?;
+    let (mins_str, s) = s.split_once("m")?;
+    if !s.is_empty() {
+        return None;
+    }
+    let hours = hours_str.parse::<u32>().ok()?;
+    let mins = mins_str.parse::<u32>().ok()?;
+    Some(hours * 60 + mins)
+}
+
+fn parse_time_with_units(s: &str, converter: &Converter) -> Result<u32, ParseTimeError> {
+    let to_minutes = |value, unit| {
+        if converter.unit_count() == 0 {
+            hard_coded_time_units(value, unit)
+        } else {
+            dynamic_time_units(value, unit, converter)
+        }
+    };
+
+    let mut total = 0.0;
+    let mut parts = s.split_whitespace();
+    while let Some(part) = parts.next() {
+        let first_non_digit_pos = part
+            .char_indices()
+            .find_map(|(pos, c)| (!c.is_numeric() && c != '.').then_some(pos));
+        let (number, unit) = if let Some(mid) = first_non_digit_pos {
+            // if the part contains a non numeric char, split it in two and it will
+            // be the unit
+            part.split_at(mid)
+        } else {
+            // otherwise, take the next part as the unit
+            let next = parts.next().ok_or(ParseTimeError::MissingUnit)?;
+            (part, next)
+        };
+        let number = number.parse::<f64>()?;
+        total += to_minutes(number, unit)?;
+    }
+    Ok(total.round() as u32)
+}
+
+fn dynamic_time_units(
+    value: f64,
+    unit: &str,
+    converter: &Converter,
+) -> Result<f64, ParseTimeError> {
+    // TODO maybe make this configurable? It will work for 99% of users...
+    let minutes = converter
+        .find_unit("min")
+        .or_else(|| converter.find_unit("minute"))
+        .or_else(|| converter.find_unit("minutes"))
+        .or_else(|| converter.find_unit("m"))
+        .ok_or(ParseTimeError::MinutesNotFound)?;
+    if minutes.physical_quantity != PhysicalQuantity::Time {
+        return Err(ParseTimeError::MinutesNotFound);
+    }
+    let (value, _) = converter.convert(
+        ConvertValue::Number(value),
+        ConvertUnit::Key(unit),
+        ConvertTo::from(&minutes),
+    )?;
+    match value {
+        ConvertValue::Number(n) => Ok(n),
+        _ => unreachable!(),
+    }
+}
+
+fn hard_coded_time_units(value: f64, unit: &str) -> Result<f64, ParseTimeError> {
+    let minutes = match unit {
+        "s" | "sec" | "secs" | "second" | "seconds" => value / 60.0,
+        "m" | "min" | "minute" | "minutes" => value,
+        "h" | "hour" | "hours" => value * 60.0,
+        "d" | "day" | "days" => value * 24.0 * 60.0,
+        _ => return Err(ConvertError::UnknownUnit(UnknownUnit(unit.to_string())).into()),
+    };
+    Ok(minutes)
+}
+
 impl RecipeTime {
     /// Get the total time prep + cook (minutes)
     pub fn total(self) -> u32 {
@@ -562,16 +776,51 @@ impl RecipeTime {
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub(crate) enum MetadataError {
-    #[error("Unexpected value data type")]
-    UnexpectedType,
-    #[error("Value is not an emoji: {value}")]
-    NotEmoji { value: String },
+    #[error("Expected '{expected}' but got '{got}'")]
+    BadType { expected: MetaType, got: MetaType },
+    #[error("Expected sequence of '{expected}' but got '{got}'")]
+    BadSequenceType { expected: MetaType, got: MetaType },
     #[error(transparent)]
     ParseIntError(#[from] std::num::ParseIntError),
     #[error("Duplicate servings: {servings:?}")]
     DuplicateServings { servings: Vec<u32> },
     #[error(transparent)]
     ParseTimeError(#[from] ParseTimeError),
+    #[error("Invalid locale: {0}")]
+    InvalidLocale(String),
+}
+
+impl MetadataError {
+    fn expect_type(expected: MetaType, val: &serde_yaml::Value) -> Self {
+        let got = MetaType::from(val);
+        Self::BadType { expected, got }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::Display, strum::AsRefStr)]
+#[strum(serialize_all = "snake_case")]
+pub(crate) enum MetaType {
+    String,
+    Bool,
+    Number,
+    Sequence,
+    Mapping,
+    Null,
+    Unknown,
+}
+
+impl From<&serde_yaml::Value> for MetaType {
+    fn from(value: &serde_yaml::Value) -> Self {
+        match value {
+            serde_yaml::Value::Null => Self::Null,
+            serde_yaml::Value::Bool(_) => Self::Bool,
+            serde_yaml::Value::Number(_) => Self::Number,
+            serde_yaml::Value::String(_) => Self::String,
+            serde_yaml::Value::Sequence(_) => Self::Sequence,
+            serde_yaml::Value::Mapping(_) => Self::Mapping,
+            serde_yaml::Value::Tagged(_) => Self::Unknown,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -601,27 +850,22 @@ mod tests {
 
     #[test]
     fn special_keys() {
-        let t = |s: &str, key: StdKey| {
-            assert_eq!(StdKey::from_str(s).unwrap(), key);
-            assert_eq!(key.to_string(), s);
-        };
-        let t_alias = |s: &str, key: StdKey| {
-            assert_eq!(StdKey::from_str(s).unwrap(), key);
-            assert_ne!(key.to_string(), s);
-        };
-
-        t("description", StdKey::Description);
-        t("tags", StdKey::Tags);
-        t_alias("tag", StdKey::Tags);
-        t("emoji", StdKey::Emoji);
-        t("author", StdKey::Author);
-        t("source", StdKey::Source);
-        t("time", StdKey::Time);
-        t("prep time", StdKey::PrepTime);
-        t_alias("prep_time", StdKey::PrepTime);
-        t("cook time", StdKey::CookTime);
-        t_alias("cook_time", StdKey::CookTime);
-        t("servings", StdKey::Servings);
+        let t = |k: StdKey| assert_eq!(k, StdKey::from_str(k.as_ref()).unwrap());
+        t(StdKey::Title);
+        t(StdKey::Description);
+        t(StdKey::Tags);
+        t(StdKey::Author);
+        t(StdKey::Source);
+        t(StdKey::Servings);
+        t(StdKey::Course);
+        t(StdKey::Locale);
+        t(StdKey::Time);
+        t(StdKey::PrepTime);
+        t(StdKey::CookTime);
+        t(StdKey::Difficulty);
+        t(StdKey::Cuisine);
+        t(StdKey::Diet);
+        t(StdKey::Images);
     }
 
     #[test]
@@ -720,20 +964,5 @@ mod tests {
         t_no_name("   <https://rachel.url>", "https://rachel.url/");
         t_no_name_no_url("");
         t_no_name_no_url("   ");
-    }
-
-    #[test]
-    fn shortcode_emoji() {
-        let v = serde_yaml::Value::from("taco");
-        let r = value_as_emoji(&v);
-        assert!(r.is_err());
-
-        let v = serde_yaml::Value::from(":taco:");
-        let r = value_as_emoji(&v);
-        assert_eq!(r.unwrap(), "🌮");
-
-        let v = serde_yaml::Value::from("🌮");
-        let r = value_as_emoji(&v);
-        assert_eq!(r.unwrap(), "🌮");
     }
 }

--- a/src/scale.rs
+++ b/src/scale.rs
@@ -384,7 +384,7 @@ impl ScalableRecipe {
     /// Get the defined number of servings in the recipe
     ///
     /// This is set automatically from the metadata. To change it manually use
-    /// [`set_servings`].
+    /// [`set_servings`](ScalableRecipe::set_servings).
     pub fn servings(&self) -> Option<&[u32]> {
         if let Servings(Some(s)) = &self.data {
             Some(s.as_slice())


### PR DESCRIPTION
This PR adds support for all the [canonical metadata](https://cooklang.org/docs/spec/#canonical-metadata) keys. I added a bunch of methods that will help the conversions from a YAML value to a known data structure/type.

The basic usage is something like
```rust
use cooklang::metadata::CooklangValueExt; // trait that adds more conversions to a YAML value

let metadata = &recipe.metadata;
let course = metadata.get(StdKey::Course)?.as_str()?;
let tags = metadata.get(StdKey::Tags)?.as_tags()?;
```

When the expected type is clear I added a more direct method. For example, for tags you can also do:

```rust
let tags = metadata.tags()?;
```

---

Time can now be **always** parsed from `HhMm` like the spec says. No spaces.

Also, when `time` is used with `cook time` and `prep time`, **`time` always takes precedence**. I know I asked in the discord but the `serde_yaml::Mapping` API made it difficult to implement last one gets preference, and this is much simpler. The warning is emitted telling the user `prep time`/`cook time` has been overriden so I think it's no big problem.

---

I dind't merge it myself just to confirm the API is ok and that I didn't missinterpret the spec.