### PR TITLE
fix: Correct spelling `ouput` -> `output` and `bunlded` -> `bundled`

### DIFF
--- a/playground/src/lib.rs
+++ b/playground/src/lib.rs
@@ -69,7 +69,7 @@ impl State {
                     format!("{ast:#?}")
                 }
             }
-            None => "<no ouput>".to_string(),
+            None => "<no output>".to_string(),
         };
         FallibleResult::new(value, report, input)
     }
@@ -84,7 +84,7 @@ impl State {
                     format!("{r:#?}")
                 }
             }
-            None => "<no ouput>".to_string(),
+            None => "<no output>".to_string(),
         };
         FallibleResult::new(value, report, input)
     }
@@ -100,7 +100,7 @@ impl State {
                 };
                 render(r, self.parser.converter())
             }
-            None => "<no ouput>".to_string(),
+            None => "<no output>".to_string(),
         };
         FallibleResult::new(value, report, input)
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -384,7 +384,7 @@ impl<T> PassResult<T> {
 
     /// Transform into a common Rust [`Result`]
     ///
-    /// If the result is valid, the [`Ok`] variant holds the ouput and a
+    /// If the result is valid, the [`Ok`] variant holds the output and a
     /// report with only warnings. Otherwise [`Err`] holds a report with the
     /// errors (and warnings).
     pub fn into_result(mut self) -> Result<(T, SourceReport), SourceReport> {
@@ -400,7 +400,7 @@ impl<T> PassResult<T> {
         self.report
     }
 
-    /// Transform into the ouput discarding errors/warnings
+    /// Transform into the output discarding errors/warnings
     pub fn into_output(self) -> Option<T> {
         self.output
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,7 +185,7 @@ impl CooklangParser {
 
     /// Creates a new extended parser
     ///
-    /// This enables all extensions and uses the bunlded units.
+    /// This enables all extensions and uses the bundled units.
     /// It is encouraged to reuse the parser and not rebuild it every time.
     #[cfg(feature = "bundled_units")]
     pub fn extended() -> Self {


### PR DESCRIPTION
Correcting some spelling errors I noticed reading the code.