### PR TITLE
fix(playground): Don't hide servings input by default

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -179,7 +179,7 @@
           <option value="ast">AST</option>
           <option value="stdmeta">Standard metadata</option>
         </select>
-        <div hidden id="servingscontainer">
+        <div id="servingscontainer">
           <label for="servings">Servings</label>
           <input type="number" name="servings" id="servings" />
         </div>


### PR DESCRIPTION
In reference to: ![image](https://github.com/user-attachments/assets/d7feaa42-93d5-4740-a33d-d264250ebaf5)

In the playground, it uses mode `Render` by default if there are no search params or local storage to override that. However, it doesn't correctly unhide the input. The solution is to not hide it by default. Then if the mode isn't `Render` upon loading the page, it will hide it in `setMode()`.

This way, the initial html will reflect the default state of `mode=render`.

Right now it is necessary to switch to another mode and then back to see the servings input