### PR TITLE
Feat/recipe reference

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -165,6 +165,7 @@ pub enum Item {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct RecipeReference {
+    pub name: String,
     pub components: Vec<String>
 }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -163,6 +163,11 @@ pub enum Item {
     },
 }
 
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct RecipeReference {
+    pub components: Vec<String>
+}
+
 /// A recipe ingredient
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct Ingredient<V: QuantityValue = Value> {
@@ -176,6 +181,8 @@ pub struct Ingredient<V: QuantityValue = Value> {
     pub quantity: Option<Quantity<V>>,
     /// Note
     pub note: Option<String>,
+    /// Recipe reference
+    pub reference: Option<RecipeReference>,
     /// How the cookware is related to others
     pub relation: IngredientRelation,
     pub(crate) modifiers: Modifiers,

--- a/src/scale.rs
+++ b/src/scale.rs
@@ -273,6 +273,7 @@ impl Scale for Ingredient<ScalableValue> {
             alias: self.alias,
             quantity,
             note: self.note,
+            reference: self.reference,
             relation: self.relation,
             modifiers: self.modifiers,
         };
@@ -285,6 +286,7 @@ impl Scale for Ingredient<ScalableValue> {
             alias: self.alias,
             quantity: self.quantity.map(Quantity::default_scale),
             note: self.note,
+            reference: self.reference,
             relation: self.relation,
             modifiers: self.modifiers,
         }


### PR DESCRIPTION
Adds support for relative paths as proposed in https://github.com/cooklang/spec/blob/main/proposals/0015-other-recipes.md.

I think we should keep extension syntax `@@recipe` for backward compatibility.Adds support for relative paths as proposed in https://github.com/cooklang/spec/blob/main/proposals/0015-other-recipes.md.