### PR TITLE
feat: use floating value for scaling factor

### DIFF
--- a/bindings/src/lib.rs
+++ b/bindings/src/lib.rs
@@ -9,7 +9,7 @@ use aisle::*;
 use model::*;
 
 #[uniffi::export]
-pub fn parse_recipe(input: String, scaling_factor: u32) -> CooklangRecipe {
+pub fn parse_recipe(input: String, scaling_factor: f64) -> CooklangRecipe {
     let parser = cooklang::CooklangParser::canonical();
 
     let (parsed, _warnings) = parser.parse(&input).into_result().unwrap();
@@ -20,7 +20,7 @@ pub fn parse_recipe(input: String, scaling_factor: u32) -> CooklangRecipe {
 }
 
 #[uniffi::export]
-pub fn parse_metadata(input: String, scaling_factor: u32) -> CooklangMetadata {
+pub fn parse_metadata(input: String, scaling_factor: f64) -> CooklangMetadata {
     let mut metadata = CooklangMetadata::new();
     let parser = cooklang::CooklangParser::canonical();
 
@@ -132,7 +132,7 @@ mod tests {
 a test @step @salt{1%mg} more text
 "#
             .to_string(),
-            1
+            1.0
         );
 
         assert_eq!(
@@ -209,7 +209,7 @@ source: https://google.com
 a test @step @salt{1%mg} more text
 "#
             .to_string(),
-            1
+            1.0
         );
 
         assert_eq!(
@@ -357,7 +357,7 @@ dried oregano
 Cook @onions{3%large} until brown
 "#
             .to_string(),
-            1
+            1.0
         );
 
         let first_section = recipe
@@ -416,7 +416,7 @@ add @tomatoes{400%g}
 simmer for 10 minutes
 "#
             .to_string(),
-            1
+            1.0
         );
         let first_section = recipe
             .sections
@@ -481,7 +481,7 @@ Mix @flour{200%g} and @water{50%ml} together until smooth.
 Combine @cheese{100%g} and @spinach{50%g}, then season to taste.
 "#
             .to_string(),
-            1
+            1.0
         );
 
         let mut sections = recipe.sections.into_iter();

--- a/src/scale.rs
+++ b/src/scale.rs
@@ -18,6 +18,7 @@ pub struct ScaleTarget {
 impl ScaleTarget {
     /// Creates a new [`ScaleTarget`].
     ///
+    /// - `factor` is the multiplier to scale the recipe by.
     /// Invalid parameters don't error here, but may do so in the
     /// scaling process.
     fn new(factor: f64) -> Self {

--- a/src/scale.rs
+++ b/src/scale.rs
@@ -12,38 +12,23 @@ use crate::{
 /// Configures the scaling target
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct ScaleTarget {
-    base: u32,
-    target: u32,
-    index: Option<usize>,
+    factor: f64
 }
 
 impl ScaleTarget {
     /// Creates a new [`ScaleTarget`].
-    /// - `base` is the number of servings the recipe was initially written for.
-    ///   Usually this is the first value of `declared_servings` but doesn't
-    ///   need to.
-    /// - `target` is the wanted number of servings.
-    /// - `declared_servigs` is the slice with all the servings of the recipe
-    ///   metadata.
     ///
     /// Invalid parameters don't error here, but may do so in the
     /// scaling process.
-    fn new(base: u32, target: u32, declared_servings: &[u32]) -> Self {
+    fn new(factor: f64) -> Self {
         ScaleTarget {
-            base,
-            target,
-            index: declared_servings.iter().position(|&s| s == target),
+            factor,
         }
     }
 
     /// Get the calculated scaling factor
     pub fn factor(&self) -> f64 {
-        self.target as f64 / self.base as f64
-    }
-
-    /// Get the target servings
-    pub fn target_servings(&self) -> u32 {
-        self.target
+        self.factor
     }
 }
 
@@ -122,13 +107,8 @@ impl ScalableRecipe {
     ///
     /// Note that this returns a [`ScaledRecipe`] wich doesn't implement this
     /// method. A recipe can only be scaled once.
-    pub fn scale(self, target: u32, converter: &Converter) -> ScaledRecipe {
-        let target = if let Servings(Some(servings)) = &self.data {
-            let base = servings.first().copied().unwrap_or(1);
-            ScaleTarget::new(base, target, servings)
-        } else {
-            ScaleTarget::new(1, target, &[])
-        };
+    pub fn scale(self, factor: f64, converter: &Converter) -> ScaledRecipe {
+        let target = ScaleTarget::new(factor);
 
         let (ingredients, ingredient_outcomes): (Vec<_>, Vec<_>) = self
             .ingredients
@@ -173,6 +153,17 @@ impl ScalableRecipe {
             inline_quantities: self.inline_quantities,
             data: Scaled::Scaled(data),
         }
+    }
+
+    /// - `target` is the wanted number of servings.
+    pub fn scale_to_servings(self, target: u32, converter: &Converter) -> ScaledRecipe {
+        let base = if let Servings(Some(servings)) = &self.data {
+            servings.first().copied().unwrap_or(1)
+        } else {
+            1
+        };
+
+        self.scale(target as f64 / base as f64, converter)
     }
 
     /// Scale the recipe to the default values


### PR DESCRIPTION
To implement support of baking percentages, we need to be able to scale recipes with arbitrary non-integer scaling factors. It also detaches implementation from servings and uses just scaling factor, leaving it to a caller decide how this scaling factor is calculated. I provided fallback function to support cases that work old-way with base and target servings.