### PR TITLE
IngredientList to recognise references

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -169,6 +169,12 @@ pub struct RecipeReference {
     pub components: Vec<String>
 }
 
+impl RecipeReference {
+    pub fn path(&self, separator: &str) -> String {
+        self.components.join(separator) + separator + &self.name
+    }
+}
+
 /// A recipe ingredient
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct Ingredient<V: QuantityValue = Value> {


### PR DESCRIPTION
To facilitate downstream applications, we need an extra option to skip adding references as names when grouping ingredients for shopping list. Also returns these references back so caller can deal with them separately.