### PR TITLE
Metadata in typescript

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -5,6 +5,9 @@ use std::{borrow::Cow, num::ParseFloatError, str::FromStr};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+#[cfg(feature = "ts")]
+use tsify::Tsify;
+
 use crate::{
     convert::{ConvertError, ConvertTo, ConvertUnit, ConvertValue, PhysicalQuantity, UnknownUnit},
     Converter,
@@ -23,8 +26,10 @@ use crate::{
 /// was not present or the value was not of the expected type. You can also
 /// decide to not use them and extract the metadata you prefer.
 #[derive(Debug, PartialEq, Clone, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(Tsify))]
 pub struct Metadata {
     /// All the raw key/value pairs from the recipe
+    #[cfg_attr(feature = "ts", tsify(type = "Record<any, any>"))]
     pub map: serde_yaml::Mapping,
 }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -26,7 +26,6 @@ use crate::{
 #[cfg_attr(feature = "ts", derive(Tsify))]
 pub struct Recipe {
     /// Metadata
-    #[cfg_attr(feature = "ts", serde(skip))]
     pub metadata: Metadata,
     /// Each of the sections
     ///

--- a/typescript/test/types.test.ts
+++ b/typescript/test/types.test.ts
@@ -1,10 +1,24 @@
-import { it, expectTypeOf } from "vitest";
-import { Parser } from "..";
-import type { ScaledRecipeWithReport } from "..";
+import {it, expectTypeOf, expect} from "vitest";
+import {Parser} from "..";
+import type {ScaledRecipeWithReport} from "..";
+import {Metadata} from "../pkg";
 
 it("generates Recipe type", async () => {
-  const parser = new Parser();
-  const recipeRaw = "this could be a recipe";
-  const recipe = parser.parse(recipeRaw);
-  expectTypeOf(recipe).toEqualTypeOf<ScaledRecipeWithReport>();
+    const parser = new Parser();
+    const recipeRaw = "this could be a recipe";
+    const recipe = parser.parse(recipeRaw);
+    expectTypeOf(recipe).toEqualTypeOf<ScaledRecipeWithReport>();
+});
+
+it("generates metadata", async () => {
+    const parser = new Parser();
+    const recipeRaw = `
+---
+key: value
+---
+aaa bbb
+    `;
+    const recipe = parser.parse(recipeRaw);
+    expectTypeOf(recipe.recipe.metadata).toEqualTypeOf<Metadata>();
+    expect(recipe.recipe.metadata.map["key"]).equals("value");
 });

--- a/typescript/tsconfig.json
+++ b/typescript/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "target": "es2015",
+    "lib": [
+      "es2015"
+    ]
+  }
+}


### PR DESCRIPTION
Ts parser should return metadata too. https://github.com/cooklang/cooklang-rs/issues/53 without docs.

Currently playground manually reads a few of standard tags separately from parser. This commit should allow to parse any standard or custom tags in one call to full parse. Result is properly typed in typescript.

Also, created minimal tsconfig.json, so that ide won't show errors