### PR TITLE
interpreted metadata in typescipt parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,6 +315,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
+ "serde_yaml",
  "tsify",
  "wasm-bindgen",
 ]

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -67,12 +67,13 @@ impl std::fmt::Display for StdKey {
 }
 
 #[derive(thiserror::Error, Debug, Clone)]
-#[error("Faile to parse '{0}' as a standard key")]
+#[error("Failed to parse '{0}' as a standard key")]
 pub struct StdKeyParseError(String);
 
 impl FromStr for StdKey {
     type Err = StdKeyParseError;
 
+    // TODO: error: alternative names are neither used as aliases nor emitted as custom tags
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let k = match s {
             "title" => Self::Title,
@@ -577,9 +578,12 @@ impl std::fmt::Display for Servings {
 ///
 /// At least one of the fields is [`Some`].
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ts", derive(Tsify))]
 #[serde(deny_unknown_fields)]
 pub struct NameAndUrl {
+    #[cfg_attr(feature = "ts", tsify(optional))]
     name: Option<String>,
+    #[cfg_attr(feature = "ts", tsify(optional))]
     url: Option<String>,
 }
 
@@ -654,6 +658,7 @@ fn is_url(s: &str) -> bool {
 ///
 /// All values are in minutes.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "ts", derive(Tsify))]
 #[serde(untagged, deny_unknown_fields)]
 pub enum RecipeTime {
     /// Total time
@@ -663,8 +668,10 @@ pub enum RecipeTime {
     /// At least one is [`Some`]
     Composed {
         #[serde(alias = "prep")]
+        #[cfg_attr(feature = "ts", tsify(optional))]
         prep_time: Option<u32>,
         #[serde(alias = "cook")]
+        #[cfg_attr(feature = "ts", tsify(optional))]
         cook_time: Option<u32>,
     },
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -25,7 +25,8 @@ use crate::{
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 #[cfg_attr(feature = "ts", derive(Tsify))]
 pub struct Recipe {
-    /// Metadata
+    /// Metadata as read from preamble
+    #[cfg_attr(feature = "ts", serde(rename = "raw_metadata"))]
     pub metadata: Metadata,
     /// Each of the sections
     ///

--- a/src/scale.rs
+++ b/src/scale.rs
@@ -158,6 +158,7 @@ impl Recipe {
         converter: &Converter,
     ) -> Result<(), ScaleError> {
         // Get current yield from metadata
+        // TODO: use std keys
         let yield_value = self.metadata.get("yield").ok_or(ScaleError::InvalidYield)?;
 
         let yield_str = yield_value
@@ -187,6 +188,7 @@ impl Recipe {
         self.scale(factor, converter);
 
         // Update yield metadata to the target value (always use % format)
+        // TODO: use std keys
         if let Some(yield_meta) = self.metadata.get_mut("yield") {
             *yield_meta = serde_yaml::Value::String(format!("{target_value}%{target_unit}"));
         }

--- a/typescript/Cargo.toml
+++ b/typescript/Cargo.toml
@@ -16,6 +16,7 @@ serde_json = "1"
 serde-wasm-bindgen = "0.6"
 maud = "0.26.0"
 tsify = "0.5"
+serde_yaml = "0.9.34+deprecated"
 
 [build-dependencies]
 git2 = { version = "0.20", default-features = false }

--- a/typescript/index.ts
+++ b/typescript/index.ts
@@ -1,4 +1,56 @@
-import { version, Parser } from "./pkg/cooklang_wasm";
+import {
+    version,
+    Parser,
+    InterpretedMetadata,
+    NameAndUrl,
+    RecipeTime,
+    Servings
+} from "./pkg/cooklang_wasm";
 
-export { version, Parser };
-export type { ScaledRecipeWithReport } from "./pkg/cooklang_wasm";
+export {version, Parser};
+export type {ScaledRecipeWithReport} from "./pkg/cooklang_wasm";
+
+export class CooklangRecipe {
+    title?: string;
+    description?: string;
+    tags?: string[];
+    author?: NameAndUrl;
+    source?: NameAndUrl;
+    course?: any;
+    time?: RecipeTime;
+    servings?: Servings;
+    difficulty?: any;
+    cuisine?: any;
+    diet?: any;
+    images?: any;
+    locale?: [string, string?];
+    custom_metadata: Map<any, any>;
+
+    constructor(raw?: string) {
+        if (raw) {
+            const parser = new Parser();
+            const recipe = parser.parse(raw);
+            this.setMetadata(recipe.metadata);
+        }
+    }
+
+    private setMetadata(metadata: InterpretedMetadata) {
+        this.title = metadata.title;
+        this.description = metadata.description;
+        this.tags = metadata.tags;
+        this.author = metadata.author;
+        this.source = metadata.source;
+        this.course = metadata.course;
+        this.time = metadata.time;
+        this.servings = metadata.servings;
+        this.difficulty = metadata.difficulty;
+        this.cuisine = metadata.cuisine;
+        this.diet = metadata.diet;
+        this.images = metadata.images;
+        this.locale = metadata.locale;
+
+        this.custom_metadata = new Map();
+        for (let key in metadata.custom)
+            this.custom_metadata.set(key, metadata.custom[key]);
+    }
+}

--- a/typescript/src/lib.rs
+++ b/typescript/src/lib.rs
@@ -1,9 +1,10 @@
 use cooklang::ast::build_ast;
 use cooklang::error::SourceReport;
-use cooklang::metadata::{CooklangValueExt, NameAndUrl, RecipeTime};
+use cooklang::metadata::{CooklangValueExt, NameAndUrl, RecipeTime, Servings, StdKey};
 use cooklang::{parser::PullParser, Extensions};
 use cooklang::{Converter, CooklangParser, IngredientReferenceTarget, Item};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::fmt::Write;
 use tsify::Tsify;
 use wasm_bindgen::prelude::*;
@@ -21,9 +22,43 @@ pub struct Parser {
 }
 
 #[derive(Tsify, Serialize, Deserialize)]
+pub struct InterpretedMetadata {
+    #[tsify(optional)]
+    title: Option<String>,
+    #[tsify(optional)]
+    description: Option<String>,
+    #[tsify(optional)]
+    tags: Option<Vec<String>>,
+    #[tsify(optional)]
+    author: Option<NameAndUrl>,
+    #[tsify(optional)]
+    source: Option<NameAndUrl>,
+    #[tsify(optional, type = "any")]
+    course: Option<serde_yaml::Value>,
+    #[tsify(optional)]
+    time: Option<RecipeTime>,
+    #[tsify(optional)]
+    servings: Option<Servings>,
+    #[tsify(optional, type = "any")]
+    difficulty: Option<serde_yaml::Value>,
+    #[tsify(optional, type = "any")]
+    cuisine: Option<serde_yaml::Value>,
+    #[tsify(optional, type = "any")]
+    diet: Option<serde_yaml::Value>,
+    #[tsify(optional, type = "any")]
+    images: Option<serde_yaml::Value>,
+    #[tsify(optional)]
+    locale: Option<(String, Option<String>)>,
+
+    #[tsify(type = "Record<any, any>")]
+    custom: HashMap<serde_yaml::Value, serde_yaml::Value>,
+}
+
+#[derive(Tsify, Serialize, Deserialize)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 pub struct ScaledRecipeWithReport {
     recipe: cooklang::Recipe,
+    metadata: InterpretedMetadata,
     report: String,
 }
 
@@ -87,8 +122,37 @@ impl Parser {
         let (recipe, _report) = self.parser.parse(input).into_tuple();
         let mut recipe = recipe.expect("expected recipe");
         recipe.scale(1., self.parser.converter());
+
+        let metadata = InterpretedMetadata {
+            title: recipe.metadata.title().map(str::to_string),
+            description: recipe.metadata.description().map(str::to_string),
+            tags: recipe
+                .metadata
+                .tags()
+                .map(|v| v.iter().map(|s| s.to_string()).collect()),
+            author: recipe.metadata.author(),
+            source: recipe.metadata.source(),
+            course: recipe.metadata.get(StdKey::Course).cloned(),
+            time: recipe.metadata.time(self.parser.converter()),
+            servings: recipe.metadata.servings(),
+            difficulty: recipe.metadata.get(StdKey::Difficulty).cloned(),
+            cuisine: recipe.metadata.get(StdKey::Cuisine).cloned(),
+            diet: recipe.metadata.get(StdKey::Diet).cloned(),
+            images: recipe.metadata.get(StdKey::Images).cloned(),
+            locale: recipe
+                .metadata
+                .locale()
+                .map(|(a, b)| (a.to_string(), b.map(str::to_string))),
+            custom: recipe
+                .metadata
+                .map_filtered()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect(),
+        };
+
         let data = ScaledRecipeWithReport {
             recipe,
+            metadata,
             report: "<no output>".to_string(),
         };
         data
@@ -299,5 +363,5 @@ fn render(r: cooklang::Recipe, converter: &Converter) -> String {
             }
         }
     }
-    .into_string()
+        .into_string()
 }

--- a/typescript/test/recipe.test.ts
+++ b/typescript/test/recipe.test.ts
@@ -1,0 +1,44 @@
+import {it, expectTypeOf, expect} from "vitest";
+import {CooklangRecipe, Parser} from "..";
+import type {ScaledRecipeWithReport} from "..";
+
+it("reads standard metadata", async () => {
+    const input = `
+---
+title: Some title
+description: Some description
+tags: tag1,tag2
+author: Author
+source:
+    name: wiki
+    url: https://wikipedia.com
+course: dinner
+time: 3h 12min
+servings: 23
+difficulty: hard
+cuisine: norwegian
+diet: true
+image: example.png
+locale: en_US
+custom1: 44
+custom2: some string
+---
+    `;
+
+    const recipe = new CooklangRecipe(input);
+    expect(recipe.title).toEqual("Some title");
+    expect(recipe.description).toEqual("Some description");
+    expect(recipe.tags).toEqual(["tag1", "tag2"]);
+    expect(recipe.author).toEqual({name: "Author", url: null});
+    expect(recipe.source).toEqual({name: "wiki", url: "https://wikipedia.com"});
+    expect(recipe.course).toEqual("dinner");
+    expect(recipe.time).toEqual(192);
+    expect(recipe.servings).toEqual(23);
+    expect(recipe.difficulty).toEqual("hard");
+    expect(recipe.cuisine).toEqual("norwegian");
+    expect(recipe.diet).toEqual(true);
+    expect(recipe.images).toEqual("example.png");
+    expect(recipe.locale).toEqual(["en", "US"]);
+    expect(recipe.custom_metadata.get("custom1")).toEqual(44);
+    expect(recipe.custom_metadata.get("custom2")).toEqual("some string");
+});

--- a/typescript/test/types.test.ts
+++ b/typescript/test/types.test.ts
@@ -10,15 +10,15 @@ it("generates Recipe type", async () => {
     expectTypeOf(recipe).toEqualTypeOf<ScaledRecipeWithReport>();
 });
 
-it("generates metadata", async () => {
+it("generates raw metadata", async () => {
     const parser = new Parser();
     const recipeRaw = `
 ---
-key: value
+title: value
 ---
 aaa bbb
     `;
     const recipe = parser.parse(recipeRaw);
-    expectTypeOf(recipe.recipe.metadata).toEqualTypeOf<Metadata>();
-    expect(recipe.recipe.metadata.map["key"]).equals("value");
+    expectTypeOf(recipe.recipe.raw_metadata).toEqualTypeOf<Metadata>();
+    expect(recipe.recipe.raw_metadata.map["title"]).equals("value");
 });

--- a/typescript/tsconfig.json
+++ b/typescript/tsconfig.json
@@ -3,7 +3,8 @@
     "module": "NodeNext",
     "target": "es2015",
     "lib": [
-      "es2015"
+      "es2015",
+      "dom"
     ]
   }
 }


### PR DESCRIPTION
Added interpreted metadata to typescript parser. We could make interpretation on ts side, but it would be repeated work and risk of different behaviour. Raw metadata is still sent in case somebody needs it.