### PR TITLE
data put inside CooklangRecipe

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -2,6 +2,7 @@
   "name": "@cooklang/cooklang-ts",
   "version": "0.0.0",
   "license": "MIT",
+  "type": "module",
   "main": "index.js",
   "files": [
     "index.js",

--- a/typescript/test/recipe.test.ts
+++ b/typescript/test/recipe.test.ts
@@ -1,8 +1,39 @@
-import {it, expectTypeOf, expect} from "vitest";
-import {CooklangRecipe, Parser} from "..";
-import type {ScaledRecipeWithReport} from "..";
+import {it, expect} from "vitest";
+import {CooklangRecipe} from "../index.js";
 
-it("reads standard metadata", async () => {
+it("keeps raw string", async () => {
+    const input = `
+---
+title: Some title
+description: Some description
+---
+some step
+    `;
+
+    const recipe = new CooklangRecipe(input);
+    expect(recipe.raw).toEqual(input);
+
+});
+
+it("can change raw string", async () => {
+    const input = `
+---
+title: Some title
+description: Some description
+---
+some step
+    `;
+
+    const recipe = new CooklangRecipe("");
+    expect(recipe.raw).toEqual("");
+    expect(recipe.title).toEqual(undefined);
+
+    recipe.raw = input;
+    expect(recipe.raw).toEqual(input);
+    expect(recipe.title).toEqual("Some title");
+});
+
+it("reads interpreted metadata", async () => {
     const input = `
 ---
 title: Some title
@@ -28,7 +59,7 @@ custom2: some string
     const recipe = new CooklangRecipe(input);
     expect(recipe.title).toEqual("Some title");
     expect(recipe.description).toEqual("Some description");
-    expect(recipe.tags).toEqual(["tag1", "tag2"]);
+    expect(recipe.tags).toEqual(new Set(["tag1", "tag2"]));
     expect(recipe.author).toEqual({name: "Author", url: null});
     expect(recipe.source).toEqual({name: "wiki", url: "https://wikipedia.com"});
     expect(recipe.course).toEqual("dinner");
@@ -41,4 +72,23 @@ custom2: some string
     expect(recipe.locale).toEqual(["en", "US"]);
     expect(recipe.custom_metadata.get("custom1")).toEqual(44);
     expect(recipe.custom_metadata.get("custom2")).toEqual("some string");
+});
+
+it("reads data", async () => {
+    const input = `
+---
+title: Some title
+---
+A step. @ingredient #ware ~timer{2min}
+    `;
+
+    const recipe = new CooklangRecipe(input);
+    expect(recipe.rawMetadata).toEqual(new Map([
+        ["title", "Some title"],
+    ]));
+    expect(recipe.sections[0].content[0].type).toEqual("step");
+    expect(recipe.ingredients[0].name).toEqual("ingredient");
+    expect(recipe.cookware[0].name).toEqual("ware");
+    expect(recipe.timers[0].name).toEqual("timer");
+    expect(recipe.inlineQuantities).toEqual([]);
 });

--- a/typescript/test/types.test.ts
+++ b/typescript/test/types.test.ts
@@ -1,7 +1,7 @@
 import {it, expectTypeOf, expect} from "vitest";
-import {Parser} from "..";
-import type {ScaledRecipeWithReport} from "..";
-import {Metadata} from "../pkg";
+import {Parser} from "../index.js";
+import type {ScaledRecipeWithReport} from "../index.js";
+import {Metadata} from "../pkg/cooklang_wasm.js";
 
 it("generates Recipe type", async () => {
     const parser = new Parser();


### PR DESCRIPTION
Data (like ingredients and steps) are put in CooklangRecipe. Raw input can be changed, to reuse the inner parser.