### PR TITLE
Publish preview version on merge to main branch

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,6 +1,10 @@
 name: Preview
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
Extend the preview workflow to trigger on push to main branch in addition to pull requests. This brings the TypeScript implementation inline with the Rust version which can be used from any commit tag through cargo.

Fixes #54