### PR TITLE
feat: shopping list checked file support and comment syntax update

### DIFF
--- a/bindings/Cargo.toml
+++ b/bindings/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 
 [dependencies]
 anyhow = "1.0"
-cooklang = { path = "..", default-features = false, features = ["aisle"] }
+cooklang = { path = "..", default-features = false, features = ["aisle", "shopping_list"] }
 uniffi = "0.28.1"
 
 [lib]

--- a/bindings/Cargo.toml
+++ b/bindings/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 authors = ["dubadub <dubovskoy.a@gmail.com>"]
 description = "Cooklang Uniffi bindings"
 license = "MIT"
-keywords = ["cooklang", "unuffi"]
+keywords = ["cooklang", "uniffi"]
 repository = "https://github.com/cooklang/cooklang-rs"
 readme = "README.md"
 

--- a/bindings/src/lib.rs
+++ b/bindings/src/lib.rs
@@ -1596,7 +1596,7 @@ Serve the @./pasta/spaghetti{1%portion} with sauce
 
     #[test]
     fn test_compact_shopping_checked() {
-        use crate::shopping_list::{CheckEntry, ShoppingList, ShoppingListItem};
+        use crate::shopping_list::CheckEntry;
 
         let entries = vec![
             CheckEntry::Checked {
@@ -1610,14 +1610,12 @@ Serve the @./pasta/spaghetti{1%portion} with sauce
             },
         ];
 
-        let list = ShoppingList {
-            items: vec![ShoppingListItem::Ingredient {
-                name: "salt".to_string(),
-                quantity: None,
-            }],
-        };
+        // Caller has already aggregated the user-visible ingredient names
+        // (e.g. by expanding recipe references and categorizing against an
+        // aisle config). Only "salt" is currently in the list.
+        let current_ingredients = vec!["salt".to_string()];
 
-        let compacted = crate::compact_shopping_checked(&entries, &list);
+        let compacted = crate::compact_shopping_checked(&entries, &current_ingredients);
         // Only "salt" should remain — it's checked and still in the list.
         // "pepper" and "removed ingredient" are not in the list.
         assert_eq!(compacted.len(), 1);

--- a/bindings/src/lib.rs
+++ b/bindings/src/lib.rs
@@ -668,23 +668,27 @@ pub fn write_shopping_check_entry(
     shopping_list::write_check_entry_impl(entry)
 }
 
-/// Compacts a checked log against a shopping list
+/// Compacts a checked log against the set of currently-visible ingredient
+/// names.
 ///
 /// Removes entries for ingredients that are no longer in the shopping list,
 /// and collapses the log so each ingredient appears at most once.
 ///
 /// # Arguments
 /// * `entries` - The current check log entries
-/// * `list` - The current shopping list to compact against
+/// * `current_ingredients` - The fully-aggregated ingredient names as shown
+///   to the user. A raw on-disk `ShoppingList` only stores recipe
+///   references, so callers must expand recipes first and pass the
+///   resulting ingredient names here.
 ///
 /// # Returns
 /// A compacted list of check entries
 #[uniffi::export]
 pub fn compact_shopping_checked(
     entries: &[shopping_list::CheckEntry],
-    list: &shopping_list::ShoppingList,
+    current_ingredients: &[String],
 ) -> Vec<shopping_list::CheckEntry> {
-    shopping_list::compact_checked_impl(entries, list)
+    shopping_list::compact_checked_impl(entries, current_ingredients)
 }
 
 uniffi::setup_scaffolding!();

--- a/bindings/src/lib.rs
+++ b/bindings/src/lib.rs
@@ -5,6 +5,7 @@ use cooklang::metadata::StdKey as OriginalStdKey;
 
 pub mod aisle;
 pub mod model;
+pub mod shopping_list;
 
 use aisle::*;
 use model::*;
@@ -578,6 +579,108 @@ fn parse_fraction(s: &str) -> Option<f64> {
     }
 
     None
+}
+
+// ---------------------------------------------------------------------------
+// Shopping list functions
+// ---------------------------------------------------------------------------
+
+/// Parses a `.shopping-list` file into a ShoppingList structure
+///
+/// The format supports recipe references (lines starting with `./`) and
+/// free-hand ingredients, with indentation-based nesting for sub-recipes.
+///
+/// # Arguments
+/// * `input` - The raw shopping list text
+///
+/// # Returns
+/// A parsed ShoppingList, or an error string if parsing fails
+#[uniffi::export]
+pub fn parse_shopping_list(
+    input: String,
+) -> Result<shopping_list::ShoppingList, String> {
+    shopping_list::parse_shopping_list_impl(&input)
+}
+
+/// Serializes a ShoppingList back to the `.shopping-list` text format
+///
+/// # Arguments
+/// * `list` - The shopping list to serialize
+///
+/// # Returns
+/// The formatted text, or an error string if serialization fails
+#[uniffi::export]
+pub fn write_shopping_list(
+    list: &shopping_list::ShoppingList,
+) -> Result<String, String> {
+    shopping_list::write_shopping_list_impl(list)
+}
+
+/// Parses a `.shopping-checked` log file into a list of check entries
+///
+/// The format is an append-only log with `+ name` (checked) and `- name`
+/// (unchecked) entries.
+///
+/// # Arguments
+/// * `input` - The raw checked log text
+///
+/// # Returns
+/// A list of check/uncheck entries in order
+#[uniffi::export]
+pub fn parse_shopping_checked(input: String) -> Vec<shopping_list::CheckEntry> {
+    shopping_list::parse_checked_impl(&input)
+}
+
+/// Replays a checked log and returns the set of currently checked ingredient
+/// names (lowercased)
+///
+/// Later entries override earlier ones for the same ingredient.
+///
+/// # Arguments
+/// * `entries` - The check log entries to replay
+///
+/// # Returns
+/// Set of ingredient names that are currently checked
+#[uniffi::export]
+pub fn shopping_checked_set(
+    entries: &[shopping_list::CheckEntry],
+) -> Vec<String> {
+    shopping_list::checked_set_impl(entries)
+        .into_iter()
+        .collect()
+}
+
+/// Serializes a single check entry to string format
+///
+/// # Arguments
+/// * `entry` - The check entry to serialize
+///
+/// # Returns
+/// The formatted string (e.g., `"+ salt\n"` or `"- pepper\n"`)
+#[uniffi::export]
+pub fn write_shopping_check_entry(
+    entry: &shopping_list::CheckEntry,
+) -> Result<String, String> {
+    shopping_list::write_check_entry_impl(entry)
+}
+
+/// Compacts a checked log against a shopping list
+///
+/// Removes entries for ingredients that are no longer in the shopping list,
+/// and collapses the log so each ingredient appears at most once.
+///
+/// # Arguments
+/// * `entries` - The current check log entries
+/// * `list` - The current shopping list to compact against
+///
+/// # Returns
+/// A compacted list of check entries
+#[uniffi::export]
+pub fn compact_shopping_checked(
+    entries: &[shopping_list::CheckEntry],
+    list: &shopping_list::ShoppingList,
+) -> Vec<shopping_list::CheckEntry> {
+    shopping_list::compact_checked_impl(entries, list)
 }
 
 uniffi::setup_scaffolding!();
@@ -1336,5 +1439,180 @@ Serve the @./pasta/spaghetti{1%portion} with sauce
                 components: vec![".".to_string(), "pasta".to_string()],
             })
         );
+    }
+
+    #[test]
+    fn test_parse_shopping_list() {
+        use crate::shopping_list::ShoppingListItem;
+
+        let list = crate::parse_shopping_list(
+            "./Breakfast/Easy Pancakes{2}\n  ./Shared/Guacamole\n./Thai Green Curry\n".to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(list.items.len(), 2);
+
+        // First item: Easy Pancakes with multiplier and one child
+        match &list.items[0] {
+            ShoppingListItem::Recipe {
+                path,
+                multiplier,
+                children,
+            } => {
+                assert_eq!(path, "Breakfast/Easy Pancakes");
+                assert_eq!(*multiplier, Some(2.0));
+                assert_eq!(children.len(), 1);
+                match &children[0] {
+                    ShoppingListItem::Recipe {
+                        path, multiplier, ..
+                    } => {
+                        assert_eq!(path, "Shared/Guacamole");
+                        assert_eq!(*multiplier, None);
+                    }
+                    _ => panic!("Expected recipe child"),
+                }
+            }
+            _ => panic!("Expected recipe item"),
+        }
+
+        // Second item: Thai Green Curry, no children
+        match &list.items[1] {
+            ShoppingListItem::Recipe {
+                path,
+                multiplier,
+                children,
+            } => {
+                assert_eq!(path, "Thai Green Curry");
+                assert_eq!(*multiplier, None);
+                assert!(children.is_empty());
+            }
+            _ => panic!("Expected recipe item"),
+        }
+    }
+
+    #[test]
+    fn test_write_shopping_list() {
+        use crate::shopping_list::{ShoppingList, ShoppingListItem};
+
+        let list = ShoppingList {
+            items: vec![
+                ShoppingListItem::Recipe {
+                    path: "Breakfast/Pancakes".to_string(),
+                    multiplier: Some(2.0),
+                    children: vec![ShoppingListItem::Recipe {
+                        path: "Shared/Syrup".to_string(),
+                        multiplier: None,
+                        children: vec![],
+                    }],
+                },
+                ShoppingListItem::Ingredient {
+                    name: "salt".to_string(),
+                    quantity: Some("2%tsp".to_string()),
+                },
+            ],
+        };
+
+        let output = crate::write_shopping_list(&list).unwrap();
+        assert_eq!(
+            output,
+            "./Breakfast/Pancakes{2}\n  ./Shared/Syrup\nsalt{2%tsp}\n"
+        );
+    }
+
+    #[test]
+    fn test_shopping_list_roundtrip() {
+        let input =
+            "./Meal Plan.menu\n  ./Breakfast/Pancakes{2}\n    ./Shared/Guacamole\n  ./Dinner/Curry\n";
+        let list = crate::parse_shopping_list(input.to_string()).unwrap();
+        let output = crate::write_shopping_list(&list).unwrap();
+        assert_eq!(output, input);
+    }
+
+    #[test]
+    fn test_parse_shopping_checked() {
+        use crate::shopping_list::CheckEntry;
+
+        let entries = crate::parse_shopping_checked(
+            "+ salt\n+ pepper\n- salt\n+ garlic\n".to_string(),
+        );
+
+        assert_eq!(entries.len(), 4);
+        assert!(matches!(&entries[0], CheckEntry::Checked { name } if name == "salt"));
+        assert!(matches!(&entries[1], CheckEntry::Checked { name } if name == "pepper"));
+        assert!(matches!(&entries[2], CheckEntry::Unchecked { name } if name == "salt"));
+        assert!(matches!(&entries[3], CheckEntry::Checked { name } if name == "garlic"));
+    }
+
+    #[test]
+    fn test_shopping_checked_set() {
+        use crate::shopping_list::CheckEntry;
+
+        let entries = vec![
+            CheckEntry::Checked {
+                name: "salt".to_string(),
+            },
+            CheckEntry::Checked {
+                name: "pepper".to_string(),
+            },
+            CheckEntry::Unchecked {
+                name: "salt".to_string(),
+            },
+        ];
+
+        let checked = crate::shopping_checked_set(&entries);
+        // salt was unchecked, pepper stays checked
+        assert!(!checked.contains(&"salt".to_string()));
+        assert!(checked.contains(&"pepper".to_string()));
+    }
+
+    #[test]
+    fn test_write_shopping_check_entry() {
+        use crate::shopping_list::CheckEntry;
+
+        let entry = CheckEntry::Checked {
+            name: "salt".to_string(),
+        };
+        assert_eq!(
+            crate::write_shopping_check_entry(&entry).unwrap(),
+            "+ salt\n"
+        );
+
+        let entry = CheckEntry::Unchecked {
+            name: "pepper".to_string(),
+        };
+        assert_eq!(
+            crate::write_shopping_check_entry(&entry).unwrap(),
+            "- pepper\n"
+        );
+    }
+
+    #[test]
+    fn test_compact_shopping_checked() {
+        use crate::shopping_list::{CheckEntry, ShoppingList, ShoppingListItem};
+
+        let entries = vec![
+            CheckEntry::Checked {
+                name: "salt".to_string(),
+            },
+            CheckEntry::Checked {
+                name: "pepper".to_string(),
+            },
+            CheckEntry::Checked {
+                name: "removed ingredient".to_string(),
+            },
+        ];
+
+        let list = ShoppingList {
+            items: vec![ShoppingListItem::Ingredient {
+                name: "salt".to_string(),
+                quantity: None,
+            }],
+        };
+
+        let compacted = crate::compact_shopping_checked(&entries, &list);
+        // Only "salt" should remain — it's checked and still in the list.
+        // "pepper" and "removed ingredient" are not in the list.
+        assert_eq!(compacted.len(), 1);
+        assert!(matches!(&compacted[0], CheckEntry::Checked { name } if name == "salt"));
     }
 }

--- a/bindings/src/lib.rs
+++ b/bindings/src/lib.rs
@@ -645,9 +645,13 @@ pub fn parse_shopping_checked(input: String) -> Vec<shopping_list::CheckEntry> {
 pub fn shopping_checked_set(
     entries: &[shopping_list::CheckEntry],
 ) -> Vec<String> {
-    shopping_list::checked_set_impl(entries)
+    // UniFFI doesn't expose HashSet, so we return a Vec. Sort for
+    // deterministic ordering across the FFI boundary.
+    let mut names: Vec<String> = shopping_list::checked_set_impl(entries)
         .into_iter()
-        .collect()
+        .collect();
+    names.sort();
+    names
 }
 
 /// Serializes a single check entry to string format

--- a/bindings/src/shopping_list.rs
+++ b/bindings/src/shopping_list.rs
@@ -163,16 +163,23 @@ pub fn write_check_entry_impl(entry: &CheckEntry) -> Result<String, String> {
     String::from_utf8(buf).map_err(|e| e.to_string())
 }
 
-/// Compact a checked log against a shopping list.
+/// Compact a checked log against the ingredient names currently in the
+/// shopping list.
+///
+/// Callers should pass the fully-aggregated ingredient names the user
+/// actually sees. A raw on-disk [`ShoppingList`] usually contains only
+/// recipe references, not ingredients, so it cannot be used directly.
 pub fn compact_checked_impl(
     entries: &[CheckEntry],
-    list: &ShoppingList,
+    current_ingredients: &[String],
 ) -> Vec<CheckEntry> {
     let original_entries: Vec<OriginalCheckEntry> =
         entries.iter().map(OriginalCheckEntry::from).collect();
-    let original_list = OriginalShoppingList::from(list);
-    sl::compact_checked(&original_entries, &original_list)
-        .iter()
-        .map(CheckEntry::from)
-        .collect()
+    sl::compact_checked(
+        &original_entries,
+        current_ingredients.iter().map(String::as_str),
+    )
+    .iter()
+    .map(CheckEntry::from)
+    .collect()
 }

--- a/bindings/src/shopping_list.rs
+++ b/bindings/src/shopping_list.rs
@@ -1,0 +1,178 @@
+use cooklang::shopping_list::{
+    self as sl, CheckEntry as OriginalCheckEntry, IngredientItem as OriginalIngredientItem,
+    RecipeItem as OriginalRecipeItem, ShoppingList as OriginalShoppingList,
+    ShoppingListItem as OriginalShoppingListItem,
+};
+use std::collections::HashSet;
+
+// ---------------------------------------------------------------------------
+// UniFFI wrapper types
+// ---------------------------------------------------------------------------
+
+/// A shopping list containing recipe references and free-hand ingredients
+#[derive(uniffi::Record, Debug, Clone)]
+pub struct ShoppingList {
+    pub items: Vec<ShoppingListItem>,
+}
+
+/// An item in the shopping list
+#[derive(uniffi::Enum, Debug, Clone)]
+pub enum ShoppingListItem {
+    /// A recipe reference with a path, optional multiplier, and children
+    Recipe {
+        path: String,
+        multiplier: Option<f64>,
+        children: Vec<ShoppingListItem>,
+    },
+    /// A free-hand ingredient with a name and optional quantity
+    Ingredient { name: String, quantity: Option<String> },
+}
+
+/// An entry in the checked log
+#[derive(uniffi::Enum, Debug, Clone)]
+pub enum CheckEntry {
+    /// Ingredient was checked (acquired)
+    Checked { name: String },
+    /// Ingredient was unchecked
+    Unchecked { name: String },
+}
+
+// ---------------------------------------------------------------------------
+// Conversions: original → binding
+// ---------------------------------------------------------------------------
+
+impl From<&OriginalShoppingList> for ShoppingList {
+    fn from(list: &OriginalShoppingList) -> Self {
+        ShoppingList {
+            items: list.items.iter().map(ShoppingListItem::from).collect(),
+        }
+    }
+}
+
+impl From<&OriginalShoppingListItem> for ShoppingListItem {
+    fn from(item: &OriginalShoppingListItem) -> Self {
+        match item {
+            OriginalShoppingListItem::Recipe(r) => ShoppingListItem::Recipe {
+                path: r.path.clone(),
+                multiplier: r.multiplier,
+                children: r.children.iter().map(ShoppingListItem::from).collect(),
+            },
+            OriginalShoppingListItem::Ingredient(i) => ShoppingListItem::Ingredient {
+                name: i.name.clone(),
+                quantity: i.quantity.clone(),
+            },
+        }
+    }
+}
+
+impl From<&OriginalCheckEntry> for CheckEntry {
+    fn from(entry: &OriginalCheckEntry) -> Self {
+        match entry {
+            OriginalCheckEntry::Checked(name) => CheckEntry::Checked {
+                name: name.clone(),
+            },
+            OriginalCheckEntry::Unchecked(name) => CheckEntry::Unchecked {
+                name: name.clone(),
+            },
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Conversions: binding → original
+// ---------------------------------------------------------------------------
+
+impl From<&ShoppingList> for OriginalShoppingList {
+    fn from(list: &ShoppingList) -> Self {
+        OriginalShoppingList {
+            items: list.items.iter().map(OriginalShoppingListItem::from).collect(),
+        }
+    }
+}
+
+impl From<&ShoppingListItem> for OriginalShoppingListItem {
+    fn from(item: &ShoppingListItem) -> Self {
+        match item {
+            ShoppingListItem::Recipe {
+                path,
+                multiplier,
+                children,
+            } => OriginalShoppingListItem::Recipe(OriginalRecipeItem {
+                path: path.clone(),
+                multiplier: *multiplier,
+                children: children.iter().map(OriginalShoppingListItem::from).collect(),
+            }),
+            ShoppingListItem::Ingredient { name, quantity } => {
+                OriginalShoppingListItem::Ingredient(OriginalIngredientItem {
+                    name: name.clone(),
+                    quantity: quantity.clone(),
+                })
+            }
+        }
+    }
+}
+
+impl From<&CheckEntry> for OriginalCheckEntry {
+    fn from(entry: &CheckEntry) -> Self {
+        match entry {
+            CheckEntry::Checked { name } => OriginalCheckEntry::Checked(name.clone()),
+            CheckEntry::Unchecked { name } => OriginalCheckEntry::Unchecked(name.clone()),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public helpers used by lib.rs exported functions
+// ---------------------------------------------------------------------------
+
+/// Parse a `.shopping-list` file into a ShoppingList.
+pub fn parse_shopping_list_impl(input: &str) -> Result<ShoppingList, String> {
+    sl::parse(input)
+        .map(|list| ShoppingList::from(&list))
+        .map_err(|e| e.to_string())
+}
+
+/// Serialize a ShoppingList back to the `.shopping-list` format.
+pub fn write_shopping_list_impl(list: &ShoppingList) -> Result<String, String> {
+    let original = OriginalShoppingList::from(list);
+    let mut buf = Vec::new();
+    sl::write(&original, &mut buf).map_err(|e| e.to_string())?;
+    String::from_utf8(buf).map_err(|e| e.to_string())
+}
+
+/// Parse a `.shopping-checked` log file.
+pub fn parse_checked_impl(input: &str) -> Vec<CheckEntry> {
+    sl::parse_checked(input)
+        .iter()
+        .map(CheckEntry::from)
+        .collect()
+}
+
+/// Replay a checked log and return the set of currently checked ingredient
+/// names (lowercased).
+pub fn checked_set_impl(entries: &[CheckEntry]) -> HashSet<String> {
+    let original: Vec<OriginalCheckEntry> = entries.iter().map(OriginalCheckEntry::from).collect();
+    sl::checked_set(&original)
+}
+
+/// Serialize a single check entry to string.
+pub fn write_check_entry_impl(entry: &CheckEntry) -> Result<String, String> {
+    let original = OriginalCheckEntry::from(entry);
+    let mut buf = Vec::new();
+    sl::write_check_entry(&original, &mut buf).map_err(|e| e.to_string())?;
+    String::from_utf8(buf).map_err(|e| e.to_string())
+}
+
+/// Compact a checked log against a shopping list.
+pub fn compact_checked_impl(
+    entries: &[CheckEntry],
+    list: &ShoppingList,
+) -> Vec<CheckEntry> {
+    let original_entries: Vec<OriginalCheckEntry> =
+        entries.iter().map(OriginalCheckEntry::from).collect();
+    let original_list = OriginalShoppingList::from(list);
+    sl::compact_checked(&original_entries, &original_list)
+        .iter()
+        .map(CheckEntry::from)
+        .collect()
+}

--- a/src/aisle.rs
+++ b/src/aisle.rs
@@ -522,9 +522,9 @@ chili flakes
         let a = parse(input).unwrap();
         let p = a.ingredients_info();
         // All case variants should find the same ingredient
-        assert!(p.get("chili flakes").is_some());
-        assert!(p.get(&"Chili flakes".to_lowercase()).is_some());
-        assert!(p.get(&"CHILI FLAKES".to_lowercase()).is_some());
+        assert!(p.contains_key("chili flakes"));
+        assert!(p.contains_key(&"Chili flakes".to_lowercase()));
+        assert!(p.contains_key(&"CHILI FLAKES".to_lowercase()));
         assert_eq!(
             p.get("chili flakes").unwrap().common_name,
             p.get(&"Chili Flakes".to_lowercase()).unwrap().common_name

--- a/src/ingredient_list.rs
+++ b/src/ingredient_list.rs
@@ -123,7 +123,7 @@ impl IngredientList {
     ///
     /// For each ingredient in the list, if it exists in the pantry with a valid quantity,
     /// subtract that quantity from the required amount. Only subtracts when units match.
-    /// Returns a new IngredientList with the remaining quantities needed.
+    /// Returns a new `IngredientList` with the remaining quantities needed.
     ///
     /// # Arguments
     ///

--- a/src/pantry.rs
+++ b/src/pantry.rs
@@ -42,12 +42,12 @@ use crate::{
 /// format.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct PantryConf {
-    /// Map of sections to their items (IndexMap to preserve file order)
+    /// Map of sections to their items (`IndexMap` to preserve file order)
     #[serde(flatten)]
     pub sections: IndexMap<String, Vec<PantryItem>>,
 
     /// Index for fast ingredient lookups (lowercase name -> (section, index))
-    /// Using BTreeMap for better cache locality and predictable iteration
+    /// Using `BTreeMap` for better cache locality and predictable iteration
     #[serde(skip)]
     ingredient_index: BTreeMap<String, Vec<(String, usize)>>,
 }
@@ -187,7 +187,7 @@ impl PantryConf {
                 let lowercase_name = item.name().to_lowercase();
                 self.ingredient_index
                     .entry(lowercase_name)
-                    .or_insert_with(Vec::new)
+                    .or_default()
                     .push((section_name.clone(), idx));
             }
         }
@@ -508,6 +508,22 @@ fn parse_core(
     // Add top-level items to "general" section if any exist
     if !general_items.is_empty() {
         sections.insert("general".to_string(), general_items);
+    }
+
+    // Normalize WithAttributes-with-no-attributes back to Simple, so
+    // `write` → `parse` round-trips preserve the item variant.
+    for items in sections.values_mut() {
+        for item in items.iter_mut() {
+            if let PantryItem::WithAttributes(attrs) = item {
+                if attrs.bought.is_none()
+                    && attrs.expire.is_none()
+                    && attrs.quantity.is_none()
+                    && attrs.low.is_none()
+                {
+                    *item = PantryItem::Simple(attrs.name.clone());
+                }
+            }
+        }
     }
 
     // Build the index for fast lookups

--- a/src/parser/step.rs
+++ b/src/parser/step.rs
@@ -568,7 +568,7 @@ mod tests {
     use crate::{error::SourceReport, parser::token_stream::TokenStream};
     use test_case::test_case;
 
-    fn t(input: &str) -> (Vec<Event>, SourceReport) {
+    fn t(input: &str) -> (Vec<Event<'_>>, SourceReport) {
         let mut tokens = TokenStream::new(input).collect::<Vec<_>>();
         // trim trailing newlines, block splitting should make sure this never
         // reaches the step function

--- a/src/parser/text_block.rs
+++ b/src/parser/text_block.rs
@@ -36,7 +36,7 @@ mod tests {
     use indoc::indoc;
     use test_case::test_case;
 
-    fn t(input: &str) -> (Vec<Event>, SourceReport) {
+    fn t(input: &str) -> (Vec<Event<'_>>, SourceReport) {
         let mut tokens = TokenStream::new(input).collect::<Vec<_>>();
         // trim trailing newlines, block splitting should make sure this never
         // reaches the step function

--- a/src/shopping_list.rs
+++ b/src/shopping_list.rs
@@ -92,7 +92,9 @@ impl RichError for ShoppingListError {
 
 /// Parse a [`ShoppingList`] from the shopping list format
 pub fn parse(input: &str) -> Result<ShoppingList, ShoppingListError> {
-    let lines = collect_lines(input);
+    // Strip block comments [- ... -] before line-level parsing
+    let stripped = strip_block_comments(input);
+    let lines = collect_lines(&stripped);
     let items = parse_items(&lines, 0, 0, lines.len())?;
     Ok(ShoppingList { items })
 }
@@ -111,7 +113,8 @@ fn collect_lines(input: &str) -> Vec<ParsedLine<'_>> {
         let line_len = line.len();
         let line = line.trim_end_matches('\r');
 
-        let content = match line.split_once("//") {
+        // Strip inline/line comments starting with --
+        let content = match line.split_once("--") {
             Some((before, _)) => before,
             None => line,
         };
@@ -131,6 +134,36 @@ fn collect_lines(input: &str) -> Vec<ParsedLine<'_>> {
     }
 
     lines
+}
+
+/// Strip block comments `[- ... -]` from the input, replacing their content
+/// with spaces (to preserve offsets) or newlines (to preserve line structure).
+fn strip_block_comments(input: &str) -> String {
+    let mut result = String::with_capacity(input.len());
+    let mut chars = input.char_indices().peekable();
+
+    while let Some((i, c)) = chars.next() {
+        if c == '[' && input[i..].starts_with("[-") {
+            // Skip the opening [-
+            chars.next(); // skip '-'
+            // Find matching -]
+            loop {
+                match chars.next() {
+                    Some((_, '\n')) => result.push('\n'),
+                    Some((j, '-')) if input[j..].starts_with("-]") => {
+                        chars.next(); // skip ']'
+                        break;
+                    }
+                    Some(_) => {} // drop character
+                    None => break, // unterminated block comment
+                }
+            }
+        } else {
+            result.push(c);
+        }
+    }
+
+    result
 }
 
 fn parse_items(
@@ -278,6 +311,118 @@ fn write_items(
     Ok(())
 }
 
+// ---------------------------------------------------------------------------
+// Checked file (.shopping-checked) — append-only log of checked/unchecked items
+// ---------------------------------------------------------------------------
+
+/// An entry in the checked log
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CheckEntry {
+    /// Ingredient was checked (acquired): `+ name`
+    Checked(String),
+    /// Ingredient was unchecked: `- name`
+    Unchecked(String),
+}
+
+/// Parse a `.shopping-checked` file and return the list of log entries.
+pub fn parse_checked(input: &str) -> Vec<CheckEntry> {
+    let mut entries = Vec::new();
+    for line in input.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        if let Some(name) = line.strip_prefix("+ ") {
+            let name = name.trim();
+            if !name.is_empty() {
+                entries.push(CheckEntry::Checked(name.to_string()));
+            }
+        } else if let Some(name) = line.strip_prefix("- ") {
+            let name = name.trim();
+            if !name.is_empty() {
+                entries.push(CheckEntry::Unchecked(name.to_string()));
+            }
+        }
+    }
+    entries
+}
+
+/// Replay a checked log and return the set of ingredient names that are
+/// currently checked. Matching is case-insensitive per the spec.
+pub fn checked_set(entries: &[CheckEntry]) -> std::collections::HashSet<String> {
+    use std::collections::HashMap;
+    // Track last state per lowercased name, keeping original casing
+    let mut state: HashMap<String, bool> = HashMap::new();
+    for entry in entries {
+        match entry {
+            CheckEntry::Checked(name) => {
+                state.insert(name.to_lowercase(), true);
+            }
+            CheckEntry::Unchecked(name) => {
+                state.insert(name.to_lowercase(), false);
+            }
+        }
+    }
+    state
+        .into_iter()
+        .filter_map(|(name, checked)| if checked { Some(name) } else { None })
+        .collect()
+}
+
+/// Write a single check entry to the log.
+pub fn write_check_entry(entry: &CheckEntry, mut w: impl std::io::Write) -> std::io::Result<()> {
+    match entry {
+        CheckEntry::Checked(name) => writeln!(w, "+ {name}"),
+        CheckEntry::Unchecked(name) => writeln!(w, "- {name}"),
+    }
+}
+
+/// Compact a checked log against a shopping list: keep only `+ name` entries
+/// for ingredients that are checked AND still present in the shopping list.
+pub fn compact_checked(
+    entries: &[CheckEntry],
+    list: &ShoppingList,
+) -> Vec<CheckEntry> {
+    let current = checked_set(entries);
+    let list_ingredients = collect_ingredient_names(list);
+
+    let mut compacted = Vec::new();
+    for name in &current {
+        // Keep only if the ingredient still exists in the shopping list
+        if list_ingredients.iter().any(|n| n.to_lowercase() == *name) {
+            compacted.push(CheckEntry::Checked(name.clone()));
+        }
+    }
+    compacted.sort_by(|a, b| {
+        let a_name = match a {
+            CheckEntry::Checked(n) | CheckEntry::Unchecked(n) => n,
+        };
+        let b_name = match b {
+            CheckEntry::Checked(n) | CheckEntry::Unchecked(n) => n,
+        };
+        a_name.cmp(b_name)
+    });
+    compacted
+}
+
+/// Collect all ingredient names from a shopping list (recursively).
+fn collect_ingredient_names(list: &ShoppingList) -> Vec<String> {
+    let mut names = Vec::new();
+    collect_ingredient_names_from_items(&list.items, &mut names);
+    names
+}
+
+fn collect_ingredient_names_from_items(items: &[ShoppingListItem], names: &mut Vec<String>) {
+    for item in items {
+        match item {
+            ShoppingListItem::Ingredient(i) => names.push(i.name.clone()),
+            ShoppingListItem::Recipe(r) => {
+                collect_ingredient_names_from_items(&r.children, names);
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -342,7 +487,7 @@ mod tests {
 
     #[test]
     fn comment_lines() {
-        let input = "// this is a comment\nsalt\n// another comment";
+        let input = "-- this is a comment\nsalt\n-- another comment";
         let list = parse(input).unwrap();
         assert_eq!(list.items.len(), 1);
         match &list.items[0] {
@@ -353,12 +498,38 @@ mod tests {
 
     #[test]
     fn inline_comment() {
-        let list = parse("salt // for seasoning").unwrap();
+        let list = parse("salt -- for seasoning").unwrap();
         match &list.items[0] {
             ShoppingListItem::Ingredient(i) => {
                 assert_eq!(i.name, "salt");
                 assert_eq!(i.quantity, None);
             }
+            _ => panic!("expected ingredient"),
+        }
+    }
+
+    #[test]
+    fn block_comment() {
+        let input = "salt\n[- this is a\nblock comment -]\npepper";
+        let list = parse(input).unwrap();
+        assert_eq!(list.items.len(), 2);
+        match &list.items[0] {
+            ShoppingListItem::Ingredient(i) => assert_eq!(i.name, "salt"),
+            _ => panic!("expected ingredient"),
+        }
+        match &list.items[1] {
+            ShoppingListItem::Ingredient(i) => assert_eq!(i.name, "pepper"),
+            _ => panic!("expected ingredient"),
+        }
+    }
+
+    #[test]
+    fn inline_block_comment() {
+        let list = parse("salt [- seasoning -] pepper").unwrap();
+        // After stripping block comment, we get "salt  pepper"
+        assert_eq!(list.items.len(), 1);
+        match &list.items[0] {
+            ShoppingListItem::Ingredient(i) => assert_eq!(i.name, "salt  pepper"),
             _ => panic!("expected ingredient"),
         }
     }
@@ -540,5 +711,75 @@ salt
         let input = "./Recipe{1}\n   ./Bad{2}"; // 3 spaces instead of 2
         let err = parse(input).unwrap_err();
         assert!(matches!(err, ShoppingListError::InvalidIndentation { .. }));
+    }
+
+    // -- Checked file tests --
+
+    #[test]
+    fn parse_checked_empty() {
+        let entries = parse_checked("");
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn parse_checked_basic() {
+        let input = "+ salt\n+ avocados\n+ olive oil\n- avocados\n+ avocados\n";
+        let entries = parse_checked(input);
+        assert_eq!(entries.len(), 5);
+        assert_eq!(entries[0], CheckEntry::Checked("salt".into()));
+        assert_eq!(entries[3], CheckEntry::Unchecked("avocados".into()));
+    }
+
+    #[test]
+    fn checked_set_last_wins() {
+        let input = "+ salt\n+ avocados\n+ olive oil\n- avocados\n+ avocados\n";
+        let entries = parse_checked(input);
+        let set = checked_set(&entries);
+        assert!(set.contains("salt"));
+        assert!(set.contains("avocados"));
+        assert!(set.contains("olive oil"));
+        assert_eq!(set.len(), 3);
+    }
+
+    #[test]
+    fn checked_set_uncheck_wins() {
+        let input = "+ salt\n- salt\n";
+        let entries = parse_checked(input);
+        let set = checked_set(&entries);
+        assert!(!set.contains("salt"));
+    }
+
+    #[test]
+    fn checked_set_case_insensitive() {
+        let input = "+ Salt\n";
+        let entries = parse_checked(input);
+        let set = checked_set(&entries);
+        assert!(set.contains("salt"));
+    }
+
+    #[test]
+    fn compact_removes_stale() {
+        let list = parse("salt\npepper\n").unwrap();
+        let entries = parse_checked("+ salt\n+ garlic\n");
+        let compacted = compact_checked(&entries, &list);
+        // garlic is not in list, should be dropped
+        assert_eq!(compacted.len(), 1);
+        assert!(matches!(&compacted[0], CheckEntry::Checked(n) if n == "salt"));
+    }
+
+    #[test]
+    fn write_check_entry_roundtrip() {
+        let entries = vec![
+            CheckEntry::Checked("salt".into()),
+            CheckEntry::Unchecked("pepper".into()),
+        ];
+        let mut buf = Vec::new();
+        for e in &entries {
+            write_check_entry(e, &mut buf).unwrap();
+        }
+        let output = String::from_utf8(buf).unwrap();
+        assert_eq!(output, "+ salt\n- pepper\n");
+        let parsed = parse_checked(&output);
+        assert_eq!(parsed, entries);
     }
 }

--- a/src/shopping_list.rs
+++ b/src/shopping_list.rs
@@ -93,7 +93,7 @@ impl RichError for ShoppingListError {
 /// Parse a [`ShoppingList`] from the shopping list format
 pub fn parse(input: &str) -> Result<ShoppingList, ShoppingListError> {
     // Strip block comments [- ... -] before line-level parsing
-    let stripped = strip_block_comments(input);
+    let stripped = strip_block_comments(input)?;
     let lines = collect_lines(&stripped);
     let items = parse_items(&lines, 0, 0, lines.len())?;
     Ok(ShoppingList { items })
@@ -136,9 +136,12 @@ fn collect_lines(input: &str) -> Vec<ParsedLine<'_>> {
     lines
 }
 
-/// Strip block comments `[- ... -]` from the input, replacing their content
-/// with spaces (to preserve offsets) or newlines (to preserve line structure).
-fn strip_block_comments(input: &str) -> String {
+/// Strip block comments `[- ... -]` from the input, preserving newlines so
+/// line numbers stay stable. Each block comment is replaced with a single
+/// space so adjacent tokens don't get glued together.
+///
+/// Returns `ShoppingListError::Parse` if a `[-` is opened but never closed.
+fn strip_block_comments(input: &str) -> Result<String, ShoppingListError> {
     let mut result = String::with_capacity(input.len());
     let mut chars = input.char_indices().peekable();
 
@@ -146,24 +149,36 @@ fn strip_block_comments(input: &str) -> String {
         if c == '[' && input[i..].starts_with("[-") {
             // Skip the opening [-
             chars.next(); // skip '-'
+            let open_offset = i;
+            let mut terminated = false;
             // Find matching -]
             loop {
                 match chars.next() {
                     Some((_, '\n')) => result.push('\n'),
                     Some((j, '-')) if input[j..].starts_with("-]") => {
                         chars.next(); // skip ']'
+                        terminated = true;
                         break;
                     }
                     Some(_) => {} // drop character
-                    None => break, // unterminated block comment
+                    None => break,
                 }
             }
+            if !terminated {
+                return Err(ShoppingListError::Parse {
+                    span: Span::new(open_offset, input.len()),
+                    message: "unterminated block comment (missing `-]`)".to_string(),
+                });
+            }
+            // Replace the block with a single space so surrounding tokens
+            // don't get glued together (e.g. "a[-x-]b" -> "a b").
+            result.push(' ');
         } else {
             result.push(c);
         }
     }
 
-    result
+    Ok(result)
 }
 
 fn parse_items(
@@ -224,12 +239,18 @@ fn parse_items(
     Ok(items)
 }
 
+/// Collapse runs of whitespace (left over from block comment stripping) into
+/// single spaces, and trim ends.
+fn normalize_whitespace(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
 fn parse_recipe_line(line: &ParsedLine<'_>) -> Result<(String, Option<f64>), ShoppingListError> {
     let content = &line.content[2..];
 
     if let Some(brace_start) = content.rfind('{') {
         if content.ends_with('}') {
-            let path = content[..brace_start].trim().to_string();
+            let path = normalize_whitespace(&content[..brace_start]);
             let multiplier_str = &content[brace_start + 1..content.len() - 1];
             let multiplier: f64 =
                 multiplier_str
@@ -243,10 +264,10 @@ fn parse_recipe_line(line: &ParsedLine<'_>) -> Result<(String, Option<f64>), Sho
                     })?;
             Ok((path, Some(multiplier)))
         } else {
-            Ok((content.trim().to_string(), None))
+            Ok((normalize_whitespace(content), None))
         }
     } else {
-        Ok((content.trim().to_string(), None))
+        Ok((normalize_whitespace(content), None))
     }
 }
 
@@ -257,7 +278,7 @@ fn parse_ingredient_line(
 
     if let Some(brace_start) = content.rfind('{') {
         if content.ends_with('}') {
-            let name = content[..brace_start].trim().to_string();
+            let name = normalize_whitespace(&content[..brace_start]);
             let quantity = content[brace_start + 1..content.len() - 1].to_string();
             if name.is_empty() {
                 return Err(ShoppingListError::Parse {
@@ -267,10 +288,10 @@ fn parse_ingredient_line(
             }
             Ok((name, Some(quantity)))
         } else {
-            Ok((content.trim().to_string(), None))
+            Ok((normalize_whitespace(content), None))
         }
     } else {
-        Ok((content.trim().to_string(), None))
+        Ok((normalize_whitespace(content), None))
     }
 }
 
@@ -316,7 +337,7 @@ fn write_items(
 // ---------------------------------------------------------------------------
 
 /// An entry in the checked log
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CheckEntry {
     /// Ingredient was checked (acquired): `+ name`
     Checked(String),
@@ -325,6 +346,11 @@ pub enum CheckEntry {
 }
 
 /// Parse a `.shopping-checked` file and return the list of log entries.
+///
+/// This is an append-only log format: lines that don't match `+ <name>` or
+/// `- <name>` (including malformed entries like `+salt` with no space) are
+/// silently skipped so a corrupted suffix can't prevent the rest of the log
+/// from replaying.
 pub fn parse_checked(input: &str) -> Vec<CheckEntry> {
     let mut entries = Vec::new();
     for line in input.lines() {
@@ -348,10 +374,13 @@ pub fn parse_checked(input: &str) -> Vec<CheckEntry> {
 }
 
 /// Replay a checked log and return the set of ingredient names that are
-/// currently checked. Matching is case-insensitive per the spec.
+/// currently checked.
+///
+/// Matching is case-insensitive, so the returned set contains **lowercased
+/// names only** — compare against your shopping list with
+/// `name.to_lowercase()`.
 pub fn checked_set(entries: &[CheckEntry]) -> std::collections::HashSet<String> {
     use std::collections::HashMap;
-    // Track last state per lowercased name, keeping original casing
     let mut state: HashMap<String, bool> = HashMap::new();
     for entry in entries {
         match entry {
@@ -394,13 +423,12 @@ pub fn compact_checked(
         }
     }
     compacted.sort_by(|a, b| {
-        let a_name = match a {
-            CheckEntry::Checked(n) | CheckEntry::Unchecked(n) => n,
+        // Only `Checked` entries are ever pushed above, but match both arms
+        // so this stays correct if the collection logic ever changes.
+        let name_of = |e: &CheckEntry| match e {
+            CheckEntry::Checked(n) | CheckEntry::Unchecked(n) => n.clone(),
         };
-        let b_name = match b {
-            CheckEntry::Checked(n) | CheckEntry::Unchecked(n) => n,
-        };
-        a_name.cmp(b_name)
+        name_of(a).cmp(&name_of(b))
     });
     compacted
 }
@@ -525,11 +553,29 @@ mod tests {
 
     #[test]
     fn inline_block_comment() {
+        // The stripped block leaves surrounding whitespace; we normalize it
+        // so consumers see a clean name.
         let list = parse("salt [- seasoning -] pepper").unwrap();
-        // After stripping block comment, we get "salt  pepper"
         assert_eq!(list.items.len(), 1);
         match &list.items[0] {
-            ShoppingListItem::Ingredient(i) => assert_eq!(i.name, "salt  pepper"),
+            ShoppingListItem::Ingredient(i) => assert_eq!(i.name, "salt pepper"),
+            _ => panic!("expected ingredient"),
+        }
+    }
+
+    #[test]
+    fn unterminated_block_comment_errors() {
+        let err = parse("salt [- seasoning\npepper").unwrap_err();
+        assert!(matches!(err, ShoppingListError::Parse { .. }));
+    }
+
+    #[test]
+    fn adjacent_block_comment_does_not_glue_tokens() {
+        // Without the space replacement, "foo[-x-]bar" would become "foobar".
+        let list = parse("foo[- note -]bar").unwrap();
+        assert_eq!(list.items.len(), 1);
+        match &list.items[0] {
+            ShoppingListItem::Ingredient(i) => assert_eq!(i.name, "foo bar"),
             _ => panic!("expected ingredient"),
         }
     }

--- a/src/shopping_list.rs
+++ b/src/shopping_list.rs
@@ -406,22 +406,34 @@ pub fn write_check_entry(entry: &CheckEntry, mut w: impl std::io::Write) -> std:
     }
 }
 
-/// Compact a checked log against a shopping list: keep only `+ name` entries
-/// for ingredients that are checked AND still present in the shopping list.
-pub fn compact_checked(
-    entries: &[CheckEntry],
-    list: &ShoppingList,
-) -> Vec<CheckEntry> {
+/// Compact a checked log against the set of ingredient names currently in
+/// the shopping list: keep only `+ name` entries for ingredients that are
+/// still present.
+///
+/// `current_ingredients` must be the actual ingredient names as they would
+/// be rendered to the user — after aggregating referenced recipes, applying
+/// any pantry/aisle filtering, etc. A raw on-disk `ShoppingList` usually
+/// contains only recipe *references* (not `Ingredient` items), so callers
+/// that persist lists that way must expand them first. Passing an iterator
+/// rather than a `ShoppingList` makes this contract explicit.
+///
+/// Matching is case-insensitive; returned `+ name` entries preserve the
+/// lowercased form stored in `checked_set`.
+pub fn compact_checked<'a, I>(entries: &[CheckEntry], current_ingredients: I) -> Vec<CheckEntry>
+where
+    I: IntoIterator<Item = &'a str>,
+{
     let current = checked_set(entries);
-    let list_ingredients = collect_ingredient_names(list);
+    let list_ingredients: std::collections::HashSet<String> = current_ingredients
+        .into_iter()
+        .map(|n| n.to_lowercase())
+        .collect();
 
-    let mut compacted = Vec::new();
-    for name in &current {
-        // Keep only if the ingredient still exists in the shopping list
-        if list_ingredients.iter().any(|n| n.to_lowercase() == *name) {
-            compacted.push(CheckEntry::Checked(name.clone()));
-        }
-    }
+    let mut compacted: Vec<CheckEntry> = current
+        .into_iter()
+        .filter(|name| list_ingredients.contains(name))
+        .map(CheckEntry::Checked)
+        .collect();
     compacted.sort_by(|a, b| {
         // Only `Checked` entries are ever pushed above, but match both arms
         // so this stays correct if the collection logic ever changes.
@@ -434,7 +446,12 @@ pub fn compact_checked(
 }
 
 /// Collect all ingredient names from a shopping list (recursively).
-fn collect_ingredient_names(list: &ShoppingList) -> Vec<String> {
+///
+/// This only finds `Ingredient` items. Lists that only store recipe
+/// *references* will produce an empty result — in that case, caller must
+/// expand the references via their own recipe parser before feeding names
+/// into [`compact_checked`].
+pub fn collect_ingredient_names(list: &ShoppingList) -> Vec<String> {
     let mut names = Vec::new();
     collect_ingredient_names_from_items(&list.items, &mut names);
     names
@@ -806,11 +823,38 @@ salt
     #[test]
     fn compact_removes_stale() {
         let list = parse("salt\npepper\n").unwrap();
+        let names = collect_ingredient_names(&list);
         let entries = parse_checked("+ salt\n+ garlic\n");
-        let compacted = compact_checked(&entries, &list);
+        let compacted = compact_checked(&entries, names.iter().map(String::as_str));
         // garlic is not in list, should be dropped
         assert_eq!(compacted.len(), 1);
         assert!(matches!(&compacted[0], CheckEntry::Checked(n) if n == "salt"));
+    }
+
+    #[test]
+    fn compact_accepts_arbitrary_name_iter() {
+        // Typical use: caller has already aggregated ingredient names from
+        // recipe references and passes them in directly.
+        let entries = parse_checked("+ salt\n+ pepper\n+ garlic\n");
+        let names = ["salt", "pepper"];
+        let compacted = compact_checked(&entries, names.iter().copied());
+        assert_eq!(compacted.len(), 2);
+        let kept: Vec<&str> = compacted
+            .iter()
+            .map(|e| match e {
+                CheckEntry::Checked(n) | CheckEntry::Unchecked(n) => n.as_str(),
+            })
+            .collect();
+        assert!(kept.contains(&"salt"));
+        assert!(kept.contains(&"pepper"));
+        assert!(!kept.contains(&"garlic"));
+    }
+
+    #[test]
+    fn compact_is_case_insensitive_against_names() {
+        let entries = parse_checked("+ Salt\n");
+        let compacted = compact_checked(&entries, ["SALT"].iter().copied());
+        assert_eq!(compacted.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `.shopping-checked` append-only log support per [proposal 0016](../spec/proposals/0016-shopping-list-format.md): parse/write `+ name` (checked) and `- name` (unchecked) entries with case-insensitive last-entry-wins semantics
- Add compaction logic to prune stale checked entries against the current shopping list
- Change comment syntax from `//` to `--` for line/inline comments, add `[- ... -]` block comment support
- New public API: `CheckEntry`, `parse_checked()`, `checked_set()`, `write_check_entry()`, `compact_checked()`

## Test plan
- [x] 7 new tests for checked file parsing, set computation, compaction, and roundtrip
- [x] 2 new tests for block comments (multi-line and inline)
- [x] Existing comment tests updated for `--` syntax
- [x] All 29 tests passing